### PR TITLE
Removing AiiDA implicit dependency from qe_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,4 @@ This repository contains a set of useful tools for Quantum ESPRESSO, in particul
 
 The code is developed and maintained by the AiiDA Team and is licensed under the MIT license (see LICENSE file).
 
-## Why isn't this part of AiiDA?
-
-The intention of this repository is to provide tools for Quantum Espresso that do not require AiiDA to work.
-Both the [aiida-quantumespresso plugin](https://github.com/aiidateam/aiida-quantumespresso) and AiiDA-agnostic software like [seekpath](https://github.com/giovannipizzi/seekpath) will build upon qe-tools.
-
 

--- a/qe_tools/parsers/cpinputparser.py
+++ b/qe_tools/parsers/cpinputparser.py
@@ -22,7 +22,7 @@ class CpInputFile(QeInputFile):
             the file.
         :raises TypeError: if ``pwinput`` is a list containing any non-string
             element(s).
-        :raises aiida.common.exceptions.ParsingError: if there are issues
+        :raises qe_tools.utils.exceptions.ParsingError: if there are issues
             parsing the pwinput.
         """
 

--- a/qe_tools/parsers/pwinputparser.py
+++ b/qe_tools/parsers/pwinputparser.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Tools for parsing QE PW input files and creating AiiDa Node objects based on
-them.
-
-TODO: Parse CONSTRAINTS, OCCUPATIONS, ATOMIC_FORCES once they are implemented
-      in AiiDA
+Tools for parsing QE PW input files
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -97,7 +93,7 @@ class PwInputFile(QeInputFile):
               ``0.0`` [no offset] *or* ``0.5`` [offset by half a grid step].
               This differs from the Quantum Espresso convention, where an offset
               value of ``1`` corresponds to a half-grid-step offset, but adheres
-              to the current AiiDa convention.
+              to the current AiiDA convention.
             
 
         Examples::
@@ -167,53 +163,6 @@ class PwInputFile(QeInputFile):
         # Parse the ATOMIC_SPECIES card.
         self.atomic_species = parse_atomic_species(self.input_txt)
 
-    def get_kpointsdata(self):
-        """
-        Return a KpointsData object based on the data in the input file.
-
-        This uses all of the data in the input file to do the necessary unit
-        conversion, ect. and then creates an AiiDa KpointsData object.
-
-
-        **Note:** If the calculation uses only the gamma k-point (`if
-        self.k_points['type'] == 'gamma'`), it is necessary to also attach a
-        settings node to the calculation with `gamma_only = True`.
-
-        :return: KpointsData object of the kpoints in the input file
-        :rtype: aiida.orm.data.array.kpoints.KpointsData
-        :raises NotImplementedError: if the kpoints are
-            in a format not yet supported.
-        """
-        from aiida.orm.data.array.kpoints import KpointsData
-        # Initialize the KpointsData node
-        kpointsdata = KpointsData()
-        # Get the structure using this class's method.
-        structuredata = self.get_structuredata()
-        # Set the structure information of the kpoints node.
-        kpointsdata.set_cell_from_structure(structuredata)
-
-        # Set the kpoints and weights, doing any necessary units conversion.
-        if self.k_points['type'] == 'crystal':  # relative to recip latt vecs
-            kpointsdata.set_kpoints(
-                self.k_points['points'], weights=self.k_points['weights'])
-        elif self.k_points['type'] == 'tpiba':  # cartesian; units of 2*pi/alat
-            alat = np.linalg.norm(structuredata.cell[0])  # alat in Angstrom
-            kpointsdata.set_kpoints(
-                np.array(self.k_points['points']) * (2. * np.pi / alat),
-                weights=self.k_points['weights'],
-                cartesian=True)
-        elif self.k_points['type'] == 'automatic':
-            kpointsdata.set_kpoints_mesh(
-                self.k_points['points'], offset=self.k_points['offset'])
-        elif self.k_points['type'] == 'gamma':
-            kpointsdata.set_kpoints_mesh([1, 1, 1])
-        else:
-            raise NotImplementedError(
-                'Support for creating KpointsData from input units of {} is'
-                'not yet implemented'.format(self.k_points['type']))
-
-        return kpointsdata
-
 
 def parse_k_points(txt):
     """
@@ -242,7 +191,7 @@ def parse_k_points(txt):
               ``0.0`` [no offset] *or* ``0.5`` [offset by half a grid step].
               This differs from the Quantum Espresso convention, where an offset
               value of ``1`` corresponds to a half-grid-step offset, but adheres
-              to the current AiiDa convention.
+              to the current AiiDA convention.
 
 
         Examples::
@@ -259,7 +208,7 @@ def parse_k_points(txt):
 
             {'type': 'gamma'}
 
-    :raises aiida.common.exceptions.ParsingError: if there are issues
+    :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
     # Define re for the special-type card block.

--- a/qe_tools/parsers/qeinputparser.py
+++ b/qe_tools/parsers/qeinputparser.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Tools for parsing QE PW input files and creating AiiDa Node objects based on
-them.
-
-TODO: Parse CONSTRAINTS, OCCUPATIONS, ATOMIC_FORCES once they are implemented
-      in AiiDA
+Tools for parsing QE PW input files.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
@@ -108,7 +104,7 @@ class QeInputFile(object):
               ``0.0`` [no offset] *or* ``0.5`` [offset by half a grid step].
               This differs from the Quantum Espresso convention, where an offset
               value of ``1`` corresponds to a half-grid-step offset, but adheres
-              to the current AiiDa convention.
+              to the current AiiDA convention.
             
 
         Examples::
@@ -161,7 +157,7 @@ class QeInputFile(object):
             the file.
         :raises TypeError: if ``pwinput`` is a list containing any non-string
             element(s).
-        :raises aiida.common.exceptions.ParsingError: if there are issues
+        :raises qe_tools.utils.exceptions.ParsingError: if there are issues
             parsing the pwinput.
         """
         # Get the text of the pwinput file as a single string.
@@ -220,82 +216,6 @@ class QeInputFile(object):
             cell_parameters=self.cell_parameters)
         return structure_dict
 
-    def get_structuredata(self):
-        """
-        Return a StructureData object based on the data in the input file.
-        
-        This uses all of the data in the input file to do the necessary unit 
-        conversion, ect. and then creates an AiiDA StructureData object.
-    
-        All of the names corresponding of the Kind objects composing the 
-        StructureData object will match those found in the ATOMIC_SPECIES 
-        block, so the pseudopotentials can be linked to the calculation using 
-        the kind.name for each specific type of atom (in the event that you 
-        wish to use different pseudo's for two or more of the same atom).
-    
-        :return: StructureData object of the structure in the input file
-        :rtype: aiida.orm.data.structure.StructureData
-        :raises aiida.common.exceptions.ParsingError: if there are issues
-            parsing the input.
-        """
-        from aiida.orm.data.structure import StructureData, Kind, Site
-
-        valid_elements_regex = re.compile(
-            """
-            (?P<ele>
-H  | He |
-Li | Be | B  | C  | N  | O  | F  | Ne |
-Na | Mg | Al | Si | P  | S  | Cl | Ar |
-K  | Ca | Sc | Ti | V  | Cr | Mn | Fe | Co | Ni | Cu | Zn | Ga | Ge | As | Se | Br | Kr |
-Rb | Sr | Y  | Zr | Nb | Mo | Tc | Ru | Rh | Pd | Ag | Cd | In | Sn | Sb | Te | I  | Xe |
-Cs | Ba | Hf | Ta | W  | Re | Os | Ir | Pt | Au | Hg | Tl | Pb | Bi | Po | At | Rn |
-Fr | Ra | Rf | Db | Sg | Bh | Hs | Mt |
-
-La | Ce | Pr | Nd | Pm | Sm | Eu | Gd | Tb | Dy | Ho | Er | Tm | Yb | Lu | # Lanthanides
-Ac | Th | Pa | U  | Np | Pu | Am | Cm | Bk | Cf | Es | Fm | Md | No | Lr | # Actinides
-        )
-        [^a-z]  # Any specification of an element is followed by some number
-                # or capital letter or special character.
-""", re.X | re.I)
-
-        structure_dict = self.get_structure_from_qeinput()
-        # instance and set the cell
-        structuredata = StructureData()
-
-        structuredata.set_cell(structure_dict['cell'])
-
-        #################  KINDS ##########################
-        for mass, name, pseudo in zip(
-                structure_dict['species']['masses'],
-                structure_dict['species']['names'],
-                structure_dict['species']['pseudo_file_names']):
-            try:
-                # IMPORTANT: The symbols is parsed from the Pseudo file name
-                # Is this the best way??
-                # Should we also try from the associated kind name?
-                symbols = valid_elements_regex.search(pseudo).group(
-                    'ele').capitalize()
-            except Exception as e:
-                raise InputValidationError(
-                    'I could not read an element name in {}'.format(
-                        symbols.group(0)))
-            structuredata.append_kind(
-                Kind(
-                    name=name,
-                    symbols=symbols,
-                    mass=mass,
-                ))
-
-        [
-            structuredata.append_site(Site(
-                kind_name=sym,
-                position=pos,
-            )) for sym, pos in zip(structure_dict['atom_names'],
-                                   structure_dict['positions'])
-        ]
-
-        return structuredata
-
 
 def str2val(valstr):
     """
@@ -322,9 +242,9 @@ def str2val(valstr):
     valstr = valstr.strip()
     # Define a tuple of regular expressions to match and their corresponding
     # conversion functions.
-    re_fn_tuple = ((re.compile(r"[.](true|t)[.]",
-                               re.I), lambda s: True), (re.compile(
-                                   r"[.](false|f)[.]", re.I), lambda s: False),
+    re_fn_tuple = ((re.compile(r"[.](true|t)[.]", re.I),
+                    lambda s: True), (re.compile(r"[.](false|f)[.]",
+                                                 re.I), lambda s: False),
                    (float_re,
                     lambda s: float(s.replace('d', 'e').replace('D', 'E'))),
                    (re.compile(r"[-+]?\d+$"),
@@ -376,7 +296,7 @@ def parse_namelists(txt):
                         "ntyp": 1}
             }
 
-    :raises aiida.common.exceptions.ParsingError: if there are issues
+    :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
     # TODO: Incorporate support for algebraic expressions?
@@ -462,7 +382,7 @@ def parse_atomic_positions(txt):
                               [True, True, True]]}
 
 
-    :raises aiida.common.exceptions.ParsingError: if there are issues
+    :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
 
@@ -470,8 +390,8 @@ def parse_atomic_positions(txt):
         """
         Map strings '0', '1' strings to bools: '0' --> True; '1' --> False.
 
-        While this is opposite to the QE standard, this mapping is what needs to
-        be passed to aiida in a 'settings' ParameterData object.
+        ..note:: While this is opposite to the QE standard, this mapping is what needs to
+        be passed to AiiDA in a 'settings' ParameterData object.
         (See the _if_pos method of BasePwCpInputGenerator)
         """
         if s == '0':
@@ -620,11 +540,10 @@ def parse_atomic_positions(txt):
     #~ 'ATOMIC_POSITIONS card block:\n{}'.format(len(names), n_lines,
     #~ blockstr)
     #~ )
-    info_dict = dict(
-        units=units,
-        names=names,
-        positions=positions,
-        fixed_coords=fixed_coords)
+    info_dict = dict(units=units,
+                     names=names,
+                     positions=positions,
+                     fixed_coords=fixed_coords)
     return info_dict
 
 
@@ -655,7 +574,7 @@ def parse_cell_parameters(txt):
                       [-2.6, 8.0, 0.0],
                       [-2.6, -3.5, 7.2]]}
 
-    :raises aiida.common.exceptions.ParsingError: if there are issues
+    :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
     # Define re for the card block.
@@ -793,7 +712,7 @@ def parse_atomic_species(txt):
                                    'Al.pbe-nl-rrkjus_psl.1.0.0.UPF',
                                    'Si.pbe-nl-rrkjus_psl.1.0.0.UPF']
 
-    :raises aiida.common.exceptions.ParsingError: if there are issues
+    :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
     # Define re for atomic species card block.
@@ -1048,8 +967,8 @@ def get_cell_from_parameters(cell_parameters, system_dict, alat, using_celldm):
         # 11          Orthorhombic body-centered      celldm(2)=b/a
         #                                        celldm(3)=c/a
         #  v1=(a/2,b/2,c/2),  v2=(-a/2,b/2,c/2),  v3=(-a/2,-b/2,c/2)
-        cell = np.array([[0.5 * alat, 0.5 * b,
-                          0.5 * c], [-0.5 * alat, 0.5 * b, 0.5 * c],
+        cell = np.array([[0.5 * alat, 0.5 * b, 0.5 * c],
+                         [-0.5 * alat, 0.5 * b, 0.5 * c],
                          [-0.5 * alat, -0.5 * b, 0.5 * c]])
     elif ibrav == 12:
         # 12      Monoclinic P, unique axis c     celldm(2)=b/a
@@ -1091,11 +1010,12 @@ def get_cell_from_parameters(cell_parameters, system_dict, alat, using_celldm):
         # where alpha is the angle between axis b and c
         #     beta is the angle between axis a and c
         #    gamma is the angle between axis a and b
-        cell = np.array([[alat, 0., 0.], [b * cosg, b * sing, 0.], [
-            c * cosb, c * (cosa - cosb * cosg) / sing,
-            c * np.sqrt(1. + 2. * cosa * cosb * cosg - cosa**2 - cosb**2 -
-                        cosg**2) / sing
-        ]])
+        cell = np.array([[alat, 0., 0.], [b * cosg, b * sing, 0.],
+                         [
+                             c * cosb, c * (cosa - cosb * cosg) / sing,
+                             c * np.sqrt(1. + 2. * cosa * cosb * cosg -
+                                         cosa**2 - cosb**2 - cosg**2) / sing
+                         ]])
 
     return cell
 
@@ -1107,7 +1027,12 @@ def get_structure_from_qeinput(filepath=None,
                                atomic_positions=None,
                                cell_parameters=None):
     """
-    Function that receives either
+    This function parses a Quantum ESPRESSO input file and returns a dictionary
+    of parsed information.
+
+    This function can deal with ibrav being set different from 0 and the cell being defined
+    with celldm(n) or A,B,C, cosAB etc.
+
     :param str filepath: the filepath storing **or**
     :param str text: the string of the standard QE-input file.
     :param dict namelists: The dictionary of the namelist (optional)
@@ -1122,11 +1047,6 @@ def get_structure_from_qeinput(filepath=None,
             "cell": A 3,3 array of the cell vectors in angstrom
             "atom_names": A list of the kind names as used in the input,
         }
-
-    An instance of :py:class:`~aiida.orm.data.structure.StructureData` is initialized with kinds, positions and cell
-    as defined in the input file.
-    This function can deal with ibrav being set different from 0 and the cell being defined
-    with celldm(n) or A,B,C, cosAB etc.
     """
     # I need either a valid filepath or the text of the qeinput file:
     if filepath:
@@ -1194,11 +1114,10 @@ def get_structure_from_qeinput(filepath=None,
                                        positions_units,
                                        ', '.join(valid_positions_units)))
     ######### DEFINE SITES ######################
-    return dict(
-        positions=positions.tolist(),
-        species=atomic_species,
-        cell=cell.tolist(),
-        atom_names=atomic_positions['names'])
+    return dict(positions=positions.tolist(),
+                species=atomic_species,
+                cell=cell.tolist(),
+                atom_names=atomic_positions['names'])
 
 
 def strip_comment(string,


### PR DESCRIPTION
The code has been moved into AiiDA with PR
aiidateam/aiida-core#3216 (inside `aiida.tools`).

This was anyway needed also because the imports
used in `qe_tools` were only working from AiiDA 0.12.x or
earlier, but were failing in AiiDA 1.0.

In this way, we make this package independent of AiiDA.
As such, this commit also fixes #3