### PR TITLE
Simplify parser __init__ interface.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# VSCode project settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/qe_tools/__init__.py
+++ b/qe_tools/__init__.py
@@ -1,3 +1,3 @@
 from .parsers import PwInputFile, CpInputFile
 
-__version__ = "1.1.4"
+__version__ = "2.0.0dev"

--- a/qe_tools/parsers/pwinputparser.py
+++ b/qe_tools/parsers/pwinputparser.py
@@ -125,7 +125,6 @@ class PwInputFile(QeInputFile):
                                    'Si3 28.0855 Si.pbe-nl-rrkjus_psl.1.0.0.UPF']
 
     """
-
     def __init__(self, pwinput):
         """
         Parse inputs's namelist and cards to create attributes of the info.

--- a/qe_tools/parsers/qeinputparser.py
+++ b/qe_tools/parsers/qeinputparser.py
@@ -130,70 +130,30 @@ class QeInputFile:
                                    'Si3 28.0855 Si.pbe-nl-rrkjus_psl.1.0.0.UPF']
 
     """
-
     def __init__(self, pwinput):
         """
         Parse inputs's namelist and cards to create attributes of the info.
 
-        :param pwinput:
-            Any one of the following
+        :param pwinput:  A single string containing the pwinput file's text.
+        :type pwinput: str
 
-                * A string of the (existing) absolute path to the pwinput file.
-                * A single string containing the pwinput file's text.
-                * A list of strings, with the lines of the file as the elements.
-                * A file object. (It will be opened, if it isn't already.)
+        :raises TypeError: if ``pwinput`` is not a string.
 
-        :raises IOError: if ``pwinput`` is a file and there is a problem reading
-            the file.
-        :raises TypeError: if ``pwinput`` is a list containing any non-string
-            element(s).
         :raises qe_tools.utils.exceptions.ParsingError: if there are issues
             parsing the pwinput.
         """
-        # Get the text of the pwinput file as a single string.
-        # File.
-        if isinstance(pwinput, io.IOBase):
-            try:
-                self.input_txt = pwinput.read()
-            except IOError:
-                raise IOError('Unable to open the provided pwinput, {}'
-                              ''.format(file.name))
-        # List.
-        elif isinstance(pwinput, list):
-            if all(isinstance(s, str) for s in pwinput):
-                self.input_txt = ''.join(pwinput)
-            else:
-                raise TypeError(
-                    'You provided a list to parse, but some elements were not '
-                    'strings. Each element should be a string containing a line'
-                    'of the pwinput file.')
-        # Path or string of the text.
-        elif isinstance(pwinput, str):
-            if os.path.isfile(pwinput):
-                if os.path.isabs(pwinput):
-                    with open(pwinput) as f:
-                        self.input_txt = f.read()
-                else:
-                    raise IOError(
-                        'Please provide the absolute path to an existing '
-                        'pwinput file.')
-            else:
-                self.input_txt = pwinput
-        else:
+        if not isinstance(pwinput, str):
             raise TypeError("Unknown type for input 'pwinput': {}".format(
                 type(pwinput)))
+
+        self.input_txt = pwinput
 
         # Check that pwinput is not empty.
         if len(self.input_txt.strip()) == 0:
             raise ParsingError('The pwinput provided was empty!')
 
-        # Take care explicitly of Windows newlines: \r\n
-        # (open would do it automatically, but if the uses passes a string
-        # this would not be done properly)
-        self.input_txt = self.input_txt.replace('\r\n', '\n')
-        # This is instead for Mac <=9 (hopefully nobody still uses it, but
-        # who knows) that just used \r
-        self.input_txt = self.input_txt.replace('\r', '\n')
+        # Convert all types of newlines to '\n'
+        self.input_txt = '\n'.join(self.input_txt.splitlines())
         # Add a newline, as a partial fix to #15
         self.input_txt += "\n"
 
@@ -375,7 +335,6 @@ def parse_atomic_positions(txt):
     :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
-
     def str01_to_bool(s):
         """
         Map strings '0', '1' strings to bools: '0' --> True; '1' --> False.

--- a/setup.json
+++ b/setup.json
@@ -29,9 +29,9 @@
     "install_requires": [
         "numpy"
     ],
-    "python_requires": ">=3.5",
     "license": "MIT License",
     "name": "qe-tools",
+    "python_requires": ">=3.5",
     "url": "https://github.com/aiidateam/qe-tools",
-    "version": "1.1.4"
+    "version": "2.0.0dev"
 }

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -20,7 +20,6 @@ class CustomTestCase(unittest.TestCase):
     comparisons of dicts
     )
     """
-
     def assertNestedAlmostEqual(self, expected, actual, *args, **kwargs):
         """
         Check that dict have almost equal content, for float content.
@@ -128,57 +127,27 @@ class PwTest(CustomTestCase):
             raise ValueError(
                 "Invalid valude for 'parser': '{}'".format(parser))
 
-        in_fname = ParserClass(fname)
-        structure = in_fname.get_structure_from_qeinput()
-
-        # Check opening as file-object
-        with open(fname) as f:
-            in_fobj = ParserClass(f)
-        self.assertNestedAlmostEqual(in_fname.atomic_positions,
-                                     in_fobj.atomic_positions)
-        self.assertNestedAlmostEqual(in_fname.atomic_species,
-                                     in_fobj.atomic_species)
-        self.assertNestedAlmostEqual(in_fname.cell_parameters,
-                                     in_fobj.cell_parameters)
-        self.assertNestedAlmostEqual(in_fname.k_points, in_fobj.k_points)
-        self.assertNestedAlmostEqual(in_fname.namelists, in_fobj.namelists)
-        self.assertNestedAlmostEqual(structure,
-                                     in_fobj.get_structure_from_qeinput())
-
-        # Check opening from string with file content
         # Open in binary mode so I get also '\r\n' from Windows and I check
         # that the parser properly copes with them
-        with open(fname, 'rb') as f:
-            # I decode for python3, internally I want a string not bytes
-            # I assume it's UTF-8
-            content = f.read().decode('utf-8')
-            in_string = ParserClass(content)
-        self.assertNestedAlmostEqual(in_string.atomic_positions,
-                                     in_fobj.atomic_positions)
-        self.assertNestedAlmostEqual(in_string.atomic_species,
-                                     in_fobj.atomic_species)
-        self.assertNestedAlmostEqual(in_string.cell_parameters,
-                                     in_fobj.cell_parameters)
-        self.assertNestedAlmostEqual(in_string.k_points, in_fobj.k_points)
-        self.assertNestedAlmostEqual(in_string.namelists, in_fobj.namelists)
-        self.assertNestedAlmostEqual(in_string.get_structure_from_qeinput(),
-                                     in_fobj.get_structure_from_qeinput())
+        with open(fname, 'rb') as in_file:
+            res_obj = ParserClass(in_file.read().decode('utf-8'))
 
+        structure = res_obj.get_structure_from_qeinput()
         result = {
             # Raw, from input
-            "atomic_positions": in_fname.atomic_positions,
+            "atomic_positions": res_obj.atomic_positions,
             # Raw, from input
-            "atomic_species": in_fname.atomic_species,
+            "atomic_species": res_obj.atomic_species,
             # Raw, from input can be None
-            "cell_parameters": in_fname.cell_parameters,
-            "namelists": in_fname.namelists,
+            "cell_parameters": res_obj.cell_parameters,
+            "namelists": res_obj.namelists,
             # Parsed, always angstrom and Cartesian
             "positions_angstrom": structure['positions'],
             # Parsed, always a 3x3 matrix
             "cell": structure['cell'],
         }
         if parser != 'cp':
-            result["k_points"] = in_fname.k_points
+            result["k_points"] = res_obj.k_points
 
         ref_fname = os.path.join(reference_folder, '{}.json'.format(label))
         try:


### PR DESCRIPTION
Fixes  #31.

Instead of allowing file objects, file names, list of strings, and strings, the ``__init__`` now always takes a single string representing the input file content.