### PR TITLE
Add handling for ibrav=91/-13 to 'cell_from_parameters'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
 
 script:
     - pre-commit run
-    - python tests/test_parsers.py
+    - pytest

--- a/qe_tools/parsers/cpinputparser.py
+++ b/qe_tools/parsers/cpinputparser.py
@@ -6,17 +6,21 @@ from .qeinputparser import (QeInputFile, parse_namelists,
 
 
 class CpInputFile(QeInputFile):
-    def __init__(self, pwinput):
+    def __init__(self, pwinput, *, qe_version=None):
         """
         Parse inputs's namelist and cards to create attributes of the info.
 
-        :param pwinput:
-            Any one of the following
+        :param pwinput:  A single string containing the pwinput file's text.
+        :type pwinput: str
 
-                * A string of the (existing) absolute path to the pwinput file.
-                * A single string containing the pwinput file's text.
-                * A list of strings, with the lines of the file as the elements.
-                * A file object. (It will be opened, if it isn't already.)
+        :param qe_version: A string defining which version of QuantumESPRESSO
+            the input file is used for. This is used in cases where different
+            QE versions handle the input differently.
+            If no version is specified, it will default to the latest
+            implemented version.
+            The string must comply with the PEP440 versioning scheme.
+            Valid version strings are e.g. '6.5', '6.4.1', '6.4rc2'.
+        :type qe_version: Optional[str]
 
         :raises IOError: if ``pwinput`` is a file and there is a problem reading
             the file.
@@ -26,7 +30,7 @@ class CpInputFile(QeInputFile):
             parsing the pwinput.
         """
 
-        super().__init__(pwinput)
+        super().__init__(pwinput, qe_version=qe_version)
 
         # Parse the namelists.
         self.namelists = parse_namelists(self.input_txt)

--- a/qe_tools/parsers/pwinputparser.py
+++ b/qe_tools/parsers/pwinputparser.py
@@ -124,17 +124,21 @@ class PwInputFile(QeInputFile):
                                    'Si3 28.0855 Si.pbe-nl-rrkjus_psl.1.0.0.UPF']
 
     """
-    def __init__(self, pwinput):
+    def __init__(self, pwinput, *, qe_version=None):
         """
         Parse inputs's namelist and cards to create attributes of the info.
 
-        :param pwinput:
-            Any one of the following
+        :param pwinput:  A single string containing the pwinput file's text.
+        :type pwinput: str
 
-                * A string of the (existing) absolute path to the pwinput file.
-                * A single string containing the pwinput file's text.
-                * A list of strings, with the lines of the file as the elements.
-                * A file object. (It will be opened, if it isn't already.)
+        :param qe_version: A string defining which version of QuantumESPRESSO
+            the input file is used for. This is used in cases where different
+            QE versions handle the input differently.
+            If no version is specified, it will default to the latest
+            implemented version.
+            The string must comply with the PEP440 versioning scheme.
+            Valid version strings are e.g. '6.5', '6.4.1', '6.4rc2'.
+        :type qe_version: Optional[str]
 
         :raises IOError: if ``pwinput`` is a file and there is a problem reading
             the file.
@@ -144,7 +148,7 @@ class PwInputFile(QeInputFile):
             parsing the pwinput.
         """
 
-        super().__init__(pwinput)
+        super().__init__(pwinput, qe_version=qe_version)
 
         # Parse the namelists.
         self.namelists = parse_namelists(self.input_txt)

--- a/qe_tools/parsers/qeinputparser.py
+++ b/qe_tools/parsers/qeinputparser.py
@@ -710,7 +710,7 @@ def get_cell_from_parameters(cell_parameters, system_dict, alat, using_celldm): 
     """
     ibrav = system_dict['ibrav']
 
-    valid_ibravs = list(range(15)) + [-3, -5, -9, -12]
+    valid_ibravs = list(range(15)) + [-3, -5, -9, -12, 91]
     if ibrav not in valid_ibravs:
         raise InputValidationError('I found ibrav = {} in input, \n'
                                    'but it is not among the valid values\n'
@@ -898,6 +898,13 @@ def get_cell_from_parameters(cell_parameters, system_dict, alat, using_celldm): 
         #  v1 = (a/2,-b/2,0),  v2 = (a/2,-b/2,0),  v3 = (0,0,c)
         cell = np.array([[0.5 * alat, 0.5 * b, 0.], [0.5 * alat, -0.5 * b, 0.],
                          [0., 0., c]])
+    elif ibrav == 91:
+        # 91          Orthorhombic one-face base-centered A-type
+        #                                             celldm(2)=b/a
+        #                                             celldm(3)=c/a
+        #      v1 = (a, 0, 0),  v2 = (0,b/2,-c/2),  v3 = (0,b/2,c/2)
+        cell = np.array([[alat, 0, 0], [0, 0.5 * b, -0.5 * c],
+                         [0, 0.5 * b, 0.5 * c]])
     elif ibrav == 10:
         # 10          Orthorhombic face-centered      celldm(2)=b/a
         #                                         celldm(3)=c/a

--- a/qe_tools/utils/_qe_version.py
+++ b/qe_tools/utils/_qe_version.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Helper module for managing the QuantumESPRESSO version.
+"""
+
+from typing import Optional, Union
+from functools import total_ordering
+
+from packaging.version import Version
+
+__all__ = ('parse_version', )
+
+
+@total_ordering
+class _LatestVersionImpl:
+    """
+    Implements a 'latest' version that compares as newer to any
+    packaging.version._BaseVersion object.
+
+    The object is implemented as a singleton, meaning it can only be
+    instantiated once.
+    """
+    __instance_count = 0
+
+    def __init__(self):
+        super().__init__()
+        if self.__instance_count > 0:
+            raise TypeError('Cannot instantiate the singleton more than once.')
+        # Needs to be set at type(self) explicitly, otherwise we just
+        # create an instance attribute.
+        type(self).__instance_count += 1
+
+    def __gt__(self, other):
+        if self is other:
+            return False
+        return True
+
+
+_LATEST_VERSION = _LatestVersionImpl()
+
+
+def parse_version(
+    qe_version: Optional[Union[str, _LatestVersionImpl, Version]] = None
+) -> Union[_LatestVersionImpl, Version]:
+    """Parse the QE version string to a comparable object.
+
+    Parses the QE version string into a packaging.version.Version
+    object. If no version is given, a singleton object representing the
+    latest version is returned instead.
+    The function is idempotent, i.e. applying it to an already-parsed
+    version returns the same object.
+
+    Parameters
+    ----------
+    qe_version :
+        A string representing the QuantumESPRESSO version. Must comply
+        with the PEP440 versioning scheme. Valid versions are e.g.
+        '6.5', '6.4.1', '6.4rc2'.
+    """
+    if isinstance(qe_version, (_LatestVersionImpl, Version)):
+        return qe_version
+    if qe_version is None:
+        return _LATEST_VERSION
+    return Version(qe_version)

--- a/setup.json
+++ b/setup.json
@@ -21,7 +21,8 @@
             "yapf==0.30.0",
             "prospector==1.2.0",
             "pylint==2.4.4",
-            "mypy==0.770"
+            "mypy==0.770",
+            "pytest"
         ],
         "docs": [
             "Sphinx",
@@ -30,7 +31,8 @@
         ]
     },
     "install_requires": [
-        "numpy"
+        "numpy",
+        "packaging"
     ],
     "license": "MIT License",
     "name": "qe-tools",

--- a/tests/data/lattice_ibrav91.in
+++ b/tests/data/lattice_ibrav91.in
@@ -1,0 +1,19 @@
+ &control
+    calculation='scf',
+ /
+ &system    
+    ibrav = 91, 
+    celldm(1) =10.0, 
+    celldm(2) = 1.5,
+    celldm(3) = 2.0,
+    nat=2, ntyp=1,
+    ecutwfc = 25.0
+ /
+ &electrons
+ /
+ATOMIC_SPECIES
+ H 1.0008   H.pz-vbc.UPF
+ATOMIC_POSITIONS {angstrom}
+ H  0.00 0.00 -0.35 
+ H  0.00 0.00  0.35
+K_POINTS {gamma}

--- a/tests/data/lattice_ibrav_13.in
+++ b/tests/data/lattice_ibrav_13.in
@@ -1,0 +1,20 @@
+ &control
+    calculation='scf',
+ /
+ &system    
+    ibrav = -13,
+    celldm(1) =10.0, 
+    celldm(2) = 1.5,
+    celldm(3) = 2.0,
+    celldm(5) = 0.1,
+    nat=2, ntyp=1,
+    ecutwfc = 25.0
+ /
+ &electrons
+ /
+ATOMIC_SPECIES
+ H 1.0008   H.pz-vbc.UPF
+ATOMIC_POSITIONS {angstrom}
+ H  0.00 0.00 -0.35 
+ H  0.00 0.00  0.35
+K_POINTS {gamma}

--- a/tests/data/ref/lattice_ibrav91.json
+++ b/tests/data/ref/lattice_ibrav91.json
@@ -1,0 +1,91 @@
+{
+  "atomic_positions": {
+    "fixed_coords": [
+      [
+        false,
+        false,
+        false
+      ],
+      [
+        false,
+        false,
+        false
+      ]
+    ],
+    "names": [
+      "H",
+      "H"
+    ],
+    "positions": [
+      [
+        0.0,
+        0.0,
+        -0.35
+      ],
+      [
+        0.0,
+        0.0,
+        0.35
+      ]
+    ],
+    "units": "angstrom"
+  },
+  "atomic_species": {
+    "masses": [
+      1.0008
+    ],
+    "names": [
+      "H"
+    ],
+    "pseudo_file_names": [
+      "H.pz-vbc.UPF"
+    ]
+  },
+  "cell": [
+    [
+      5.2917720859,
+      0.0,
+      0.0
+    ],
+    [
+      0.0,
+      3.968829064425,
+      -5.2917720859
+    ],
+    [
+      0.0,
+      3.968829064425,
+      5.2917720859
+    ]
+  ],
+  "cell_parameters": null,
+  "k_points": {
+    "type": "gamma"
+  },
+  "namelists": {
+    "CONTROL": {
+      "calculation": "scf"
+    },
+    "SYSTEM": {
+      "celldm(1)": 10.0,
+      "celldm(2)": 1.5,
+      "celldm(3)": 2.0,
+      "ecutwfc": 25.0,
+      "ibrav": 91,
+      "nat": 2,
+      "ntyp": 1
+    }
+  },
+  "positions_angstrom": [
+    [
+      0.0,
+      0.0,
+      -0.35
+    ],
+    [
+      0.0,
+      0.0,
+      0.35
+    ]
+  ]
+}

--- a/tests/data/ref/lattice_ibrav_13-6.4.0.json
+++ b/tests/data/ref/lattice_ibrav_13-6.4.0.json
@@ -1,0 +1,92 @@
+{
+  "atomic_positions": {
+    "fixed_coords": [
+      [
+        false,
+        false,
+        false
+      ],
+      [
+        false,
+        false,
+        false
+      ]
+    ],
+    "names": [
+      "H",
+      "H"
+    ],
+    "positions": [
+      [
+        0.0,
+        0.0,
+        -0.35
+      ],
+      [
+        0.0,
+        0.0,
+        0.35
+      ]
+    ],
+    "units": "angstrom"
+  },
+  "atomic_species": {
+    "masses": [
+      1.0008
+    ],
+    "names": [
+      "H"
+    ],
+    "pseudo_file_names": [
+      "H.pz-vbc.UPF"
+    ]
+  },
+  "cell": [
+    [
+      -2.64588604295,
+      3.968829064425,
+      0.0
+    ],
+    [
+      -2.64588604295,
+      -3.968829064425,
+      0.0
+    ],
+    [
+      1.0583544171800001,
+      0.0,
+      10.530493491003986
+    ]
+  ],
+  "cell_parameters": null,
+  "k_points": {
+    "type": "gamma"
+  },
+  "namelists": {
+    "CONTROL": {
+      "calculation": "scf"
+    },
+    "SYSTEM": {
+      "celldm(1)": 10.0,
+      "celldm(2)": 1.5,
+      "celldm(3)": 2.0,
+      "celldm(5)": 0.1,
+      "ecutwfc": 25.0,
+      "ibrav": -13,
+      "nat": 2,
+      "ntyp": 1
+    }
+  },
+  "positions_angstrom": [
+    [
+      0.0,
+      0.0,
+      -0.35
+    ],
+    [
+      0.0,
+      0.0,
+      0.35
+    ]
+  ]
+}

--- a/tests/data/ref/lattice_ibrav_13.json
+++ b/tests/data/ref/lattice_ibrav_13.json
@@ -1,0 +1,92 @@
+{
+  "atomic_positions": {
+    "fixed_coords": [
+      [
+        false,
+        false,
+        false
+      ],
+      [
+        false,
+        false,
+        false
+      ]
+    ],
+    "names": [
+      "H",
+      "H"
+    ],
+    "positions": [
+      [
+        0.0,
+        0.0,
+        -0.35
+      ],
+      [
+        0.0,
+        0.0,
+        0.35
+      ]
+    ],
+    "units": "angstrom"
+  },
+  "atomic_species": {
+    "masses": [
+      1.0008
+    ],
+    "names": [
+      "H"
+    ],
+    "pseudo_file_names": [
+      "H.pz-vbc.UPF"
+    ]
+  },
+  "cell": [
+    [
+      2.64588604295,
+      3.968829064425,
+      0.0
+    ],
+    [
+      -2.64588604295,
+      3.968829064425,
+      0.0
+    ],
+    [
+      1.0583544171800001,
+      0.0,
+      10.530493491003986
+    ]
+  ],
+  "cell_parameters": null,
+  "k_points": {
+    "type": "gamma"
+  },
+  "namelists": {
+    "CONTROL": {
+      "calculation": "scf"
+    },
+    "SYSTEM": {
+      "celldm(1)": 10.0,
+      "celldm(2)": 1.5,
+      "celldm(3)": 2.0,
+      "celldm(5)": 0.1,
+      "ecutwfc": 25.0,
+      "ibrav": -13,
+      "nat": 2,
+      "ntyp": 1
+    }
+  },
+  "positions_angstrom": [
+    [
+      0.0,
+      0.0,
+      -0.35
+    ],
+    [
+      0.0,
+      0.0,
+      0.35
+    ]
+  ]
+}

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -269,6 +269,9 @@ class PwTest(CustomTestCase):
     def test_lattice_ibrav9(self):
         self.singletest(label='lattice_ibrav9')
 
+    def test_lattice_ibrav91(self):
+        self.singletest(label='lattice_ibrav91')
+
     # The following is for negative ibravs
 
     def test_lattice_ibrav_12(self):
@@ -321,7 +324,8 @@ def print_test_comparison(label, parser='pw', write=False):
     else:
         raise ValueError("Invalid valude for 'parser': '{}'".format(parser))
 
-    parsed = ParserClass(fname)
+    with open(fname, 'rb') as in_f:
+        parsed = ParserClass(in_f.read().decode('utf-8'))
     structure = parsed.get_structure_from_qeinput()
 
     result = {

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -108,13 +108,15 @@ class CustomTestCase(unittest.TestCase):
 
 
 class PwTest(CustomTestCase):
-    def singletest(self, label, parser='pw'):
+    def singletest(self, label, parser='pw', qe_version=None):
         """
         Run a single test.
 
         :param label: used to generate the filename (<label>.in)
         :param parser: used to define the parser to use. Possible values:
             ``pw``, ``cp``.
+        :param parser: used to define a specific QE version with which
+            to test the parser.
         """
         fname = os.path.join(data_folder, '{}.in'.format(label))
         if not os.path.isfile(fname):
@@ -130,7 +132,8 @@ class PwTest(CustomTestCase):
         # Open in binary mode so I get also '\r\n' from Windows and I check
         # that the parser properly copes with them
         with open(fname, 'rb') as in_file:
-            res_obj = ParserClass(in_file.read().decode('utf-8'))
+            res_obj = ParserClass(in_file.read().decode('utf-8'),
+                                  qe_version=qe_version)
 
         structure = res_obj.get_structure_from_qeinput()
         result = {
@@ -149,7 +152,11 @@ class PwTest(CustomTestCase):
         if parser != 'cp':
             result["k_points"] = res_obj.k_points
 
-        ref_fname = os.path.join(reference_folder, '{}.json'.format(label))
+        if qe_version is None:
+            reflabel = label
+        else:
+            reflabel = '{}-{}'.format(label, qe_version)
+        ref_fname = os.path.join(reference_folder, '{}.json'.format(reflabel))
         try:
             with open(ref_fname) as f:
                 ref = json.load(f)
@@ -276,6 +283,12 @@ class PwTest(CustomTestCase):
 
     def test_lattice_ibrav_12(self):
         self.singletest(label='lattice_ibrav_12')
+
+    def test_lattice_ibrav_13(self):
+        self.singletest(label='lattice_ibrav_13')
+
+    def test_lattice_ibrav_13_old(self):
+        self.singletest(label='lattice_ibrav_13', qe_version='6.4.0')
 
     def test_lattice_ibrav_3(self):
         self.singletest(label='lattice_ibrav_3')

--- a/tests/test_version_parse.py
+++ b/tests/test_version_parse.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the version parsing helper.
+"""
+
+import pytest
+
+from qe_tools.utils._qe_version import parse_version, _LatestVersionImpl
+
+VERSION_INPUT_SORTED = ['2.3', '6.4.1', '6.4.2a1', '6.4.2', None]
+
+
+def test_sorting():
+    """
+    Check that the parsed versions compare/sort in the correct way.
+    """
+    versions_parsed = [parse_version(inp) for inp in VERSION_INPUT_SORTED]
+    assert sorted(versions_parsed) == versions_parsed
+
+
+@pytest.mark.parametrize('input_', VERSION_INPUT_SORTED)
+def test_idempotent(input_):
+    """
+    Check that the parsing function is idempotent (returns the same
+    object when given an already-parsed object).
+    """
+    parsed = parse_version(input_)
+    parsed_twice = parse_version(parsed)
+    assert parsed is parsed_twice
+
+
+@pytest.mark.parametrize('input_', VERSION_INPUT_SORTED)
+def test_equal(input_):
+    """
+    Test that two objects created from the same input compare equal.
+    """
+    parsed1 = parse_version(input_)
+    parsed2 = parse_version(input_)
+    assert parsed1 == parsed2
+    # These tests are needed to check that the 'latest' version has
+    # a consistent ordering.
+    assert not parsed1 < parsed2
+    assert not parsed1 > parsed2
+    assert parsed1 <= parsed2
+    assert parsed1 >= parsed2
+
+
+def test_singleton():
+    """
+    Check that the '_LatestVersionImpl' singleton check works.
+    """
+    with pytest.raises(TypeError):
+        _LatestVersionImpl()


### PR DESCRIPTION
Fixes #28.

Because the meaning of ``ibrav=-13`` changed in QE version 6.4.1, this adds a way of dealing with different QE versions:

The ``parse_version`` function turns a string (e.g. ``'6.4.1'``) into a ``packaging.version.Version``. By default the latest version is used, which is implemented as a singleton object that compares as greater than any ``Version`` object.

In the interface, the version can be specified as the optional keyword-only argument ``qe_version``. Because this option needs to be available both at the top-level ``QeInputFile.__init__`` and on the free functions (e.g. ``get_cell_from_parameters``), it accepts either a string or an already-parsed version. This allows immediately parsing the version in ``QeInputFile.__init__``, while also accepting string input in ``get_cell_from_parameters``.

The way this is implemented is by making the ``parse_version`` idempotent, meaning that it will not change an already-parsed version.

In the tests, the ``qe_version`` can be passed as a keyword to ``singletest``. However, these tests currently cannot auto-generate the reference file.

Dependency changes:
- Uses `pytest` as a test runner (haven't modified the existing tests yet, but these could potentially be simplified a lot with ``pytest-regressions``)
- Adds ``packaging`` as an explicit dependency. Since this is part of the standard Python tooling (via ``setuptools``) it should usually be installed already anyway.

To be reviewed especially carefully: 
- [x] The logic for ibrav = 91/-13 matches the ``pw.x`` input description
- [x] The _public_ interface change of adding the ``qe_version`` keyword-only argument. The other changes (adding ``parse_version`` etc.) are internal-only.