### PR TITLE
Add utility to convert cell into parameters.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    error
+    ignore:WARNING the new order is not taken into account !!:UserWarning

--- a/qe_tools/generators/__init__.py
+++ b/qe_tools/generators/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import cell_conversion
+
+__all__ = ('cell_conversion', )

--- a/qe_tools/generators/cell_conversion.py
+++ b/qe_tools/generators/cell_conversion.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ('get_parameters_from_cell', )
+
+from typing import Iterable, Union, Dict, Optional
+
+import numpy as np
+import scipy.linalg as la
+
+from ..constants import bohr_to_ang
+from ..parsers.qeinputparser import get_cell_from_parameters
+
+CellT = Iterable[Iterable[float]]
+ParametersT = Dict[str, float]
+
+
+def get_parameters_from_cell(*,
+                             ibrav: int,
+                             cell: CellT,
+                             tolerance: float = 1e-4,
+                             using_celldm: bool = False,
+                             qe_version: Optional[str] = None) -> ParametersT:
+    """
+    Get the cell parameters from a given `ibrav` and cell. Only the
+    parameters necessary for the given ibrav are returned.
+
+    The cell must already conform to the QuantumESPRESSO convention
+    for the given ``ibrav`` value. This is checked by the code; the
+    strictness of the check can be controlled with the ``tolerance``
+    argument.
+
+    Note that only non-zero `ibrav` are accepted.
+
+    Parameters
+    ----------
+    ibrav :
+        Bravais-lattice index, as defined by QuantumESPRESSO.
+    cell :
+        The lattice vectors, in units of Angstrom.
+    tolerance :
+        Absolute tolerance on each entry of the cell, when checking if
+        the parameters are consistent with the given input cell.
+    using_celldm :
+        Determines the format of the parameters. By default, they are
+        given as ``A``, ``B``, ``C``, ``cosAB``, ``cosAC``, ``cosBC``.
+        If the flag is ``True``, the ``celldm(1-6)`` format is used
+        instead.
+        Note that the keys in the returned dictionary are always in
+        lowercase.
+    qe_version :
+        Defines which version of QuantumESPRESSO is used. This is
+        necessary in cases where different use different
+        definitions.
+        If no version is specified, it will default to the latest
+        implemented version.
+        The string must comply with the PEP440 versioning scheme.
+        Valid version strings are e.g. '6.5', '6.4.1', '6.4rc2'.
+
+    Raises
+    ------
+    ValueError :
+        If an invalid `ibrav` is passed, or the cell reconstructed
+        from the parameters does not match the input cell.
+    """
+
+    parameters = _get_parameters_from_cell_bare(ibrav=ibrav, cell=cell)
+
+    _check_parameters(ibrav=ibrav,
+                      cell=cell,
+                      parameters=parameters,
+                      tolerance=tolerance,
+                      qe_version=qe_version)
+
+    if using_celldm:
+        parameters = _convert_to_celldm(parameters, ibrav=ibrav)
+    return parameters
+
+
+def _get_parameters_from_cell_bare(  # pylint: disable=too-many-branches
+        *, ibrav: int, cell: CellT) -> ParametersT:
+    """
+    Implementation of the conversion from cell to parameters, without
+    checks. This function always returns the parameters in the
+    A, B, C, cosAB, cosAC, cosBC form.
+    """
+    # pylint: disable=invalid-name
+    v1, v2, v3 = [np.array(v) for v in cell]
+
+    A, B, C = ('a', 'b', 'c')
+    cosAB, cosAC, cosBC = ('cosab', 'cosac', 'cosbc')
+
+    if ibrav == 1:
+        parameters = {A: la.norm(v1)}
+    elif ibrav == 2:
+        parameters = {A: np.sqrt(2) * la.norm(v1)}
+    elif ibrav in [-3, 3]:
+        parameters = {A: 2 * la.norm(v1) / np.sqrt(3)}
+    elif ibrav == 4:
+        parameters = {A: la.norm(v1), C: la.norm(v3)}
+    elif ibrav in [5, -5]:
+        parameters = {A: la.norm(v1)}
+        parameters[cosAB] = np.dot(v1, v2) / parameters[A]**2
+    elif ibrav == 6:
+        parameters = {A: la.norm(v1), C: la.norm(v3)}
+    elif ibrav == 7:
+        parameters = {A: np.sqrt(2) * la.norm(v1[:2]), C: 2 * v1[-1]}
+    elif ibrav == 8:
+        parameters = {A: la.norm(v1), B: la.norm(v2), C: la.norm(v3)}
+    elif ibrav in [9, -9]:
+        parameters = {A: 2 * abs(v1[0]), B: 2 * abs(v1[1]), C: la.norm(v3)}
+    elif ibrav == 91:
+        parameters = {A: la.norm(v1), B: la.norm(v2 + v3), C: la.norm(v3 - v2)}
+    elif ibrav == 10:
+        parameters = {A: 2 * v1[0], B: 2 * v2[1], C: 2 * v1[2]}
+    elif ibrav == 11:
+        parameters = {A: 2 * v1[0], B: 2 * v1[1], C: 2 * v1[2]}
+    elif ibrav == 12:
+        parameters = {A: la.norm(v1), B: la.norm(v2), C: la.norm(v3)}
+        parameters[cosAB] = np.dot(v1, v2) / (parameters[A] * parameters[B])
+    elif ibrav == -12:
+        parameters = {A: la.norm(v1), B: la.norm(v2), C: la.norm(v3)}
+        parameters[cosAC] = np.dot(v1, v3) / (parameters[A] * parameters[C])
+    elif ibrav == 13:
+        parameters = {A: 2 * v1[0], B: la.norm(v2), C: 2 * v3[2]}
+        parameters[cosAB] = 2 * np.dot(v1,
+                                       v2) / (parameters[A] * parameters[B])
+    elif ibrav == -13:
+        parameters = {A: 2 * abs(v1[0]), B: 2 * abs(v1[1]), C: la.norm(v3)}
+        parameters[cosAC] = v3[0] / la.norm(v3)
+    elif ibrav == 14:
+        parameters = {A: la.norm(v1), B: la.norm(v2), C: la.norm(v3)}
+        parameters[cosAB] = np.dot(v1, v2) / (parameters[A] * parameters[B])
+        parameters[cosAC] = np.dot(v1, v3) / (parameters[A] * parameters[C])
+        parameters[cosBC] = np.dot(v2, v3) / (parameters[B] * parameters[C])
+    else:
+        raise ValueError(
+            "The given 'ibrav' value '{}' is not understood.".format(ibrav))
+    return parameters
+
+
+def _check_parameters(*,
+                      ibrav: int,
+                      parameters: ParametersT,
+                      cell: CellT,
+                      tolerance: float,
+                      qe_version: Optional[str] = None) -> None:
+    """
+    Check that the parameters describe the given cell.
+    """
+    system_dict = {
+        'ibrav': ibrav,
+        **parameters
+    }  # type: Dict[str, Union[int, float]]
+    cell_reconstructed = get_cell_from_parameters(
+        cell_parameters=None,  # this is only used for ibrav=0
+        system_dict=system_dict,
+        alat=parameters['a'],
+        using_celldm=False,
+        qe_version=qe_version)
+    if not np.allclose(cell_reconstructed, cell, rtol=0, atol=tolerance):
+        raise ValueError(
+            "The cell {} constructed with 'ibrav={}', parameters={} does not match the input cell{}."
+            .format(cell_reconstructed, ibrav, parameters, cell))
+
+
+def _convert_to_celldm(parameters: ParametersT, ibrav: int) -> ParametersT:
+    """
+    Convert parameters from A, B, C, cosAB, cosAC, cosBC to celldm(1-6).
+
+    The `ibrav` input is needed because the conversion is not the same
+    for all `ibrav` values.
+    """
+    alat = parameters.pop('a')
+
+    res_parameters = {'celldm(1)': alat / bohr_to_ang}
+
+    for in_key, out_key in [('b', 'celldm(2)'), ('c', 'celldm(3)')]:
+        if in_key in parameters:
+            res_parameters[out_key] = parameters.pop(in_key) / alat
+
+    # See subroutine abc2celldm in QE latgen.f90
+    if ibrav in (0, 14):
+        res_parameters['celldm(4)'] = parameters.pop('cosbc')
+        res_parameters['celldm(5)'] = parameters.pop('cosac')
+        res_parameters['celldm(6)'] = parameters.pop('cosab')
+    elif ibrav in (-12, -13):
+        res_parameters['celldm(5)'] = parameters.pop('cosac')
+    elif ibrav in (-5, 5, 12, 13):
+        res_parameters['celldm(4)'] = parameters.pop('cosab')
+
+    # Make sure all input parameters were used.
+    assert not parameters, 'Parameters {} not used.'.format(parameters.keys())
+
+    return res_parameters

--- a/setup.json
+++ b/setup.json
@@ -21,8 +21,9 @@
             "yapf==0.30.0",
             "prospector==1.2.0",
             "pylint==2.4.4",
-            "mypy==0.770",
-            "pytest"
+            "pytest",
+            "pytest-cases",
+            "mypy==0.770"
         ],
         "docs": [
             "Sphinx",
@@ -32,6 +33,7 @@
     },
     "install_requires": [
         "numpy",
+        "scipy",
         "packaging"
     ],
     "license": "MIT License",

--- a/tests/test_cell_conversion.py
+++ b/tests/test_cell_conversion.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import json
+import pathlib
+
+import numpy as np
+import pytest
+from pytest_cases import cases_data, case_name, cases_generator, CaseData, THIS_MODULE
+
+from qe_tools.generators.cell_conversion import get_parameters_from_cell
+
+CASES_DATA_DIR = pathlib.Path(__file__).resolve().parent / 'data' / 'ref'
+
+
+@cases_generator("case {path.name}", path=CASES_DATA_DIR.iterdir())
+def case_structure_generator(path) -> CaseData:
+    with open(str(path), 'r') as in_f:
+        case_data = json.load(in_f)
+    system_dict = case_data['namelists']['SYSTEM']
+    ibrav = system_dict['ibrav']
+    ins = {'ibrav': ibrav, 'cell': case_data['cell']}
+
+    if '-' in path.name:
+        _, qe_version_with_suffix = path.name.split('-')
+        qe_version, _ = qe_version_with_suffix.rsplit('.', 1)
+    else:
+        qe_version = None
+
+    ins = {'ibrav': ibrav, 'cell': case_data['cell'], 'qe_version': qe_version}
+
+    if ibrav == 0:
+        return ins, None, ValueError
+
+    outs = dict()
+    for key in (['a', 'b', 'c', 'cosab', 'cosac', 'cosbc'] +
+                ['celldm({})'.format(i) for i in range(1, 7)]):
+        if key in system_dict:
+            outs[key] = system_dict[key]
+
+    return ins, outs, None
+
+
+@case_name("case ibrav=0")
+def case_ibrav_zero() -> CaseData:
+    return {'cell': np.eye(3), 'ibrav': 0}, None, ValueError
+
+
+@case_name("case wrong cell")
+def case_wrong_cell() -> CaseData:
+    return {'cell': np.eye(3), 'ibrav': 3}, None, ValueError
+
+
+@cases_data(module=THIS_MODULE)
+def test_parameters_from_cell(case_data):
+    inputs, expected_output, expected_error = case_data.get()
+    if expected_error is not None:
+        with pytest.raises(expected_error):
+            get_parameters_from_cell(**inputs)
+    else:
+        if 'celldm(1)' in expected_output:
+            inputs.setdefault('using_celldm', True)
+        actual_output = get_parameters_from_cell(**inputs)
+        assert actual_output.keys() == expected_output.keys()
+        for key in expected_output:
+            assert np.isclose(expected_output[key], actual_output[key])


### PR DESCRIPTION
Blocked because it's based on #35.


## New functionality:

Adds a ``get_parameters_from_cell`` function, which converts the cell into either the ``A``, ``B``, ``C``, ``cosAB``, ``cosAC``, ``cosBC`` or the ``celldm(*)`` parameters. The function relies on ``ibrav`` being specified by the user. The existing ``get_cell_from_parameters`` is used to check the results - this detects cases where the given ``ibrav`` and ``cell`` do not match.

## Naming:

The ``get_parameters_from_cell`` is put in a new ``generators`` module. The idea behind this name is that (input-)generators are opposite to the existing (output-)parsers. It's not a great naming scheme so better ideas are very welcome.

## Scaffolding:

The `pytest-cases` library is used to create test cases, from the existing reference data for the parser.
