### PR TITLE
Add consistency check in the ATOMIC_SPECIES card block

### DIFF
--- a/qe_tools/parsers/_input_base.py
+++ b/qe_tools/parsers/_input_base.py
@@ -154,7 +154,7 @@ class _BaseInputFile:
         :param validate_species_names: A boolean flag (default: True) to enable
             the consistency check between atom names and species names inferred
             from the pseudopotential file name.
-        :type validate_species_names: Optional[bool]
+        :type validate_species_names: bool
 
         :raises TypeError: if ``content`` is not a string.
 
@@ -671,7 +671,7 @@ def _parse_atomic_species(txt, validate_species_names=True):
     :param validate_species_names: A boolean flag (default: True) to enable
         the consistency check between atom names and species names inferred
         from the pseudopotential file name.
-    :type validate_species_names: Optional[bool]
+    :type validate_species_names: bool
 
     :returns:
         A dictionary with
@@ -694,7 +694,7 @@ def _parse_atomic_species(txt, validate_species_names=True):
     :raises qe_tools.utils.exceptions.ParsingError: if there are issues
         parsing the input.
     """
-    def validate_species_name(atom_name, pseudo_file_name):
+    def _validate_species_name(atom_name, pseudo_file_name):
         """
         Check if the atom name is consistent with the species name parsed from the
         corresponding pseudopotential file name.
@@ -763,7 +763,7 @@ def _parse_atomic_species(txt, validate_species_names=True):
         masses.append(fortfloat(match.group('mass')))
         pseudo_fnms.append(match.group('pseudo'))
         if validate_species_names:
-            validate_species_name(match.group('name'), match.group('pseudo'))
+            _validate_species_name(match.group('name'), match.group('pseudo'))
     info_dict = dict(names=names, masses=masses, pseudo_file_names=pseudo_fnms)
     return info_dict
 

--- a/qe_tools/parsers/_pw_input.py
+++ b/qe_tools/parsers/_pw_input.py
@@ -125,7 +125,11 @@ class PwInputFile(_BaseInputFile):
                                    'Si3 28.0855 Si.pbe-nl-rrkjus_psl.1.0.0.UPF']
 
     """
-    def __init__(self, content, *, qe_version=None):
+    def __init__(self,
+                 content,
+                 *,
+                 qe_version=None,
+                 validate_species_names=True):
         """
         Parse inputs's namelist and cards to create attributes of the info.
 
@@ -141,6 +145,11 @@ class PwInputFile(_BaseInputFile):
             Valid version strings are e.g. '6.5', '6.4.1', '6.4rc2'.
         :type qe_version: Optional[str]
 
+        :param validate_species_names: A boolean flag (default: True) to enable
+            the consistency check between atom names and species names inferred
+            from the pseudopotential file name.
+        :type validate_species_names: Optional[bool]
+
         :raises IOError: if ``content`` is a file and there is a problem reading
             the file.
         :raises TypeError: if ``content`` is a list containing any non-string
@@ -149,7 +158,9 @@ class PwInputFile(_BaseInputFile):
             parsing the content.
         """
 
-        super().__init__(content, qe_version=qe_version)
+        super().__init__(content,
+                         qe_version=qe_version,
+                         validate_species_names=validate_species_names)
 
         # Parse the K_POINTS card.
         self.k_points = parse_k_points(self._input_txt)

--- a/qe_tools/parsers/_pw_input.py
+++ b/qe_tools/parsers/_pw_input.py
@@ -148,7 +148,7 @@ class PwInputFile(_BaseInputFile):
         :param validate_species_names: A boolean flag (default: True) to enable
             the consistency check between atom names and species names inferred
             from the pseudopotential file name.
-        :type validate_species_names: Optional[bool]
+        :type validate_species_names: bool
 
         :raises IOError: if ``content`` is a file and there is a problem reading
             the file.

--- a/tests/data/non_matching_species.in
+++ b/tests/data/non_matching_species.in
@@ -1,0 +1,38 @@
+&CONTROL
+  calculation = 'scf'
+  etot_conv_thr =   1.0000000000d-05
+  forc_conv_thr =   1.0000000000d-04
+  outdir = './out/'
+  prefix = 'aiida'
+  pseudo_dir = './pseudo/'
+  tprnfor = .true.
+  tstress = .true.
+  verbosity = 'high'
+/
+&SYSTEM
+  degauss =   1.4699723600d-02
+  ecutrho =   2.4000000000d+02
+  ecutwfc =   3.0000000000d+01
+  ibrav = 0
+  nat = 2
+  ntyp = 2
+  occupations = 'smearing'
+  smearing = 'cold'
+/
+&ELECTRONS
+  conv_thr =   2.0000000000d-10
+  electron_maxstep = 80
+  mixing_beta =   4.0000000000d-01
+/
+ATOMIC_SPECIES
+La     26.98154 Al.pbe-n-kjpaw_psl.1.0.0.UPF
+O     26.98154 Al.pbe-n-kjpaw_psl.1.0.0.UPF
+ATOMIC_POSITIONS crystal
+La           0.0000000000       0.0000000000       0.0000000000
+O           0.5000000000       0.5000000000       0.5000000000
+K_POINTS automatic
+14 14 14 0 0 0
+CELL_PARAMETERS angstrom
+      2.0200000000       2.0200000000       0.0000000000
+      2.0200000000       0.0000000000       2.0200000000
+      0.0000000000       2.0200000000       2.0200000000

--- a/tests/data/ref/non_matching_species.json
+++ b/tests/data/ref/non_matching_species.json
@@ -1,0 +1,137 @@
+{
+  "atomic_positions": {
+    "fixed_coords": [
+      [
+        false,
+        false,
+        false
+      ],
+      [
+        false,
+        false,
+        false
+      ]
+    ],
+    "names": [
+      "La",
+      "O"
+    ],
+    "positions": [
+      [
+        0.0,
+        0.0,
+        0.0
+      ],
+      [
+        0.5,
+        0.5,
+        0.5
+      ]
+    ],
+    "units": "crystal"
+  },
+  "atomic_species": {
+    "masses": [
+      26.98154,
+      26.98154
+    ],
+    "names": [
+      "La",
+      "O"
+    ],
+    "pseudo_file_names": [
+      "Al.pbe-n-kjpaw_psl.1.0.0.UPF",
+      "Al.pbe-n-kjpaw_psl.1.0.0.UPF"
+    ]
+  },
+  "cell": [
+    [
+      2.02,
+      2.02,
+      0.0
+    ],
+    [
+      2.02,
+      0.0,
+      2.02
+    ],
+    [
+      0.0,
+      2.02,
+      2.02
+    ]
+  ],
+  "cell_parameters": {
+    "cell": [
+      [
+        2.02,
+        2.02,
+        0.0
+      ],
+      [
+        2.02,
+        0.0,
+        2.02
+      ],
+      [
+        0.0,
+        2.02,
+        2.02
+      ]
+    ],
+    "units": "angstrom"
+  },
+  "k_points": {
+    "offset": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "points": [
+      14,
+      14,
+      14
+    ],
+    "type": "automatic"
+  },
+  "namelists": {
+    "CONTROL": {
+      "calculation": "scf",
+      "etot_conv_thr": 1e-05,
+      "forc_conv_thr": 0.0001,
+      "outdir": "./out/",
+      "prefix": "aiida",
+      "pseudo_dir": "./pseudo/",
+      "tprnfor": true,
+      "tstress": true,
+      "verbosity": "high"
+    },
+    "ELECTRONS": {
+      "conv_thr": 2e-10,
+      "electron_maxstep": 80,
+      "mixing_beta": 0.4
+    },
+    "SYSTEM": {
+      "degauss": 0.0146997236,
+      "ecutrho": 240.0,
+      "ecutwfc": 30.0,
+      "ibrav": 0,
+      "nat": 2,
+      "ntyp": 2,
+      "occupations": "smearing",
+      "smearing": "cold"
+    }
+  },
+  "positions_angstrom": [
+    [
+      0.0,
+      0.0,
+      0.0
+    ],
+    [
+      2.02,
+      2.02,
+      2.02
+    ]
+  ]
+}

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -108,15 +108,21 @@ class CustomTestCase(unittest.TestCase):
 
 
 class PwTest(CustomTestCase):
-    def singletest(self, label, parser='pw', qe_version=None):
+    def singletest(self,
+                   label,
+                   parser='pw',
+                   qe_version=None,
+                   validate_species_names=True):
         """
         Run a single test.
 
         :param label: used to generate the filename (<label>.in)
         :param parser: used to define the parser to use. Possible values:
             ``pw``, ``cp``.
-        :param parser: used to define a specific QE version with which
+        :param qe_version: used to define a specific QE version with which
             to test the parser.
+        :param validate_species_names: used to determine whether to validate
+            the species names against the ones parsed from the pseudo file names.
         """
         fname = os.path.join(data_folder, '{}.in'.format(label))
         if not os.path.isfile(fname):
@@ -132,8 +138,10 @@ class PwTest(CustomTestCase):
         # Open in binary mode so I get also '\r\n' from Windows and I check
         # that the parser properly copes with them
         with open(fname, 'rb') as in_file:
-            res_obj = ParserClass(in_file.read().decode('utf-8'),
-                                  qe_version=qe_version)
+            res_obj = ParserClass(
+                in_file.read().decode('utf-8'),
+                qe_version=qe_version,
+                validate_species_names=validate_species_names)
 
         structure = res_obj.structure
         result = {
@@ -303,6 +311,10 @@ class PwTest(CustomTestCase):
         with self.assertRaises(InputValidationError):
             self.singletest(label='non_matching_species')
 
+    def test_non_matching_species_no_validation(self):
+        self.singletest(label='non_matching_species',
+                        validate_species_names=False)
+
     def test_no_newline_exponential_time(self):
         """
         This tries to avoid a regression of #15
@@ -342,7 +354,8 @@ def print_test_comparison(label, parser='pw', write=False):
         raise ValueError("Invalid valude for 'parser': '{}'".format(parser))
 
     with open(fname, 'rb') as in_f:
-        parsed = ParserClass(in_f.read().decode('utf-8'))
+        parsed = ParserClass(in_f.read().decode('utf-8'),
+                             validate_species_names=False)
     structure = parsed.structure
 
     result = {

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -299,6 +299,10 @@ class PwTest(CustomTestCase):
     def test_alat_coords_with_ibrav_non0(self):
         self.singletest(label='alat_coords_with_ibrav_non0')
 
+    def test_non_matching_species_validate(self):
+        with self.assertRaises(InputValidationError):
+            self.singletest(label='non_matching_species')
+
     def test_no_newline_exponential_time(self):
         """
         This tries to avoid a regression of #15


### PR DESCRIPTION
Validate species names in the `ATOMIC_SPECIES` card block. This will check that the atom names and the species names parsed from the pseudopotential file names are the same up to an optional underscore and/or optional digits.