### PR TITLE
Allow for emtpy strings in `str2val`

### DIFF
--- a/src/qe_tools/parsers/_input_base.py
+++ b/src/qe_tools/parsers/_input_base.py
@@ -218,12 +218,13 @@ def _str2val(valstr):
     )
     # Strip any white space characters before analyzing.
     valstr = valstr.strip()
+
     # Define a tuple of regular expressions to match and their corresponding
     # conversion functions.
     re_fn_tuple = ((re.compile(r'[.](true|t)[.]',
                                re.I), lambda s: True), (re.compile(r'[.](false|f)[.]', re.I), lambda s: False),
                    (float_re, lambda s: float(s.replace('d', 'e').replace('D', 'E'))), (re.compile(r'[-+]?\d+$'), int),
-                   (re.compile(r"""['"].+['"]"""), lambda s: str(s.strip("\'\""))))
+                   (re.compile(r"""['"].*['"]"""), lambda s: str(s.strip("\'\""))))
     # Convert valstr to a value.
     val = None
     for regex, conversion_fn in re_fn_tuple:

--- a/tests/data/example_comment_in_namelist.in
+++ b/tests/data/example_comment_in_namelist.in
@@ -2,6 +2,7 @@
     pseudo_dir  = 'pseudo/'
     calculation = 'scf',
     prefix = 'Si_exc1',
+    title = ''
  /
  &system
     ibrav = 0


### PR DESCRIPTION
One of the regexes in `str2val` did cover for strings covered in single or double quotes, but it required at least 1 character between the quotes. This would cause an empty-string to raise a `ValuError`.