### PR TITLE
Devops: Update the `setup-python` action for CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,8 +16,8 @@ jobs:
         -   name: Checkout source
             uses: actions/checkout@v2
 
-        -   name: Set up Python 3.9
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.9'
 
@@ -32,18 +32,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
-
-        -   name: Set up Python
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.9'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python dependencies
             run: pip install -e .[dev]
@@ -63,18 +57,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
-        -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python dependencies
             run: pip install -e .[dev]
@@ -93,7 +81,7 @@ jobs:
             uses: actions/checkout@v2
 
         -   name: Set up Python 3.9
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.9'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            id: cache-pip
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-pre-commit-
-
         -   name: Install Python
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
             with:
                 python-version: '3.9'
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python package and dependencies
             run: pip install -e .[dev]
@@ -42,19 +35,12 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Cache Python dependencies
-            id: cache-pip
-            uses: actions/cache@v1
-            with:
-                path: ~/.cache/pip
-                key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                restore-keys:
-                    pip-${{ matrix.python-version }}-tests
-
-        -   name: Install Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v2
+        -   name: Install Python
+            uses: actions/setup-python@v4
             with:
                 python-version: ${{ matrix.python-version }}
+                cache: 'pip'
+                cache-dependency-path: pyproject.toml
 
         -   name: Install Python package and dependencies
             run: pip install -e .[dev]


### PR DESCRIPTION
The `setup-python@v2` action was outdated and is updated to `setup-python@v4`. This also now comes with in-built caching functionality for the requirements which allows to replace the separate action that was providing this funcitonality.