### PR TITLE
Dependencies: Drop support for Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9']
+                python-version: ['3.8', '3.9']
 
         steps:
         -   uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8', '3.9']
+                python-version: ['3.8', '3.9']
 
         steps:
         -   uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: flynt
 
 -   repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
     -   id: isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ license = {file = 'LICENSE.txt'}
 classifiers = [
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Operating System :: OS Independent',
@@ -20,7 +18,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Chemistry',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
-requires-python = '>=3.6'
+requires-python = '>=3.8'
 dependencies = [
     'numpy',
     'scipy',


### PR DESCRIPTION
These versions have been end-of-life since 2021-12-23 and 2023-06-27 respectively: https://devguide.python.org/versions/#versions