### PR TITLE
Add missing import path for `extractors`

### DIFF
--- a/src/qe_tools/__init__.py
+++ b/src/qe_tools/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """A set of useful tools to manage Quantum ESPRESSO files."""
 from ._constants import DEFAULT as CONSTANTS  # isort:skip
-from . import converters, exceptions, parsers  # isort:skip
+from . import converters, exceptions, parsers, extractors  # isort:skip
 
 __version__ = '2.1.0'
 
-__all__ = ('CONSTANTS', 'parsers', 'converters', 'exceptions')
+__all__ = ('CONSTANTS', 'parsers', 'converters', 'exceptions', 'extractors')


### PR DESCRIPTION
Imported `extractors` module in main `__init__.py` to support `from qe_tools.extractors import extract` path needed by MaRDA extractors system.