### PR TITLE
🔧 `copier`: update package template to v0.11.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.10.0
+_commit: v0.11.1
 _src_path: https://github.com/mbercx/python-copier
 description: Tools for running and parsing Quantum ESPRESSO calculations
 doc_deploy: rtd

--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: pip install click==8.2.1 hatch
           
       - name: Run pre-commit
-        run: hatch run precommit:run
+        run: hatch run pre-commit:run
 
   tests:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install click==8.1.8 hatch
-      - run: hatch run tests:run
+      - run: hatch test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,11 @@
 repos:
-- repo: local
-  hooks:
-  - id: format
-    name: Format with Ruff
-    entry: hatch fmt -f
-    language: system
-    types: [python]
-  - id: Lint with Ruff
-    name: lint
-    entry: hatch fmt -l
-    language: system
-    types: [python]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff-check
+        name: Lint with Ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      - id: ruff-format
+        name: Format with Ruff
+        types_or: [ python, pyi ]

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,34 +1,163 @@
 # Developer Guide
 
-## Hatch
+## Quick start
 
-We use [Hatch](https://hatch.pypa.io/latest) to set up environments and scripts for most developer tasks.
-To see a table of the available environmens and their scripts, run:
+Thanks for contributing! 🙏
+Below you can find an overview of the commands to get you up and running quickly.
 
-    hatch env show
+First clone the repository from GitHub
 
-### Documentation
+    git clone <GITHUB-REPO>
 
-The easiest way to work on the documentation is to start the server locally via:
+and install the package locally in **editable** mode (`-e`):
 
-    hatch run docs:serve
+    cd qe-tools
+    pip install -e .
 
-And go to the provided URL.
-If you only want to build the documentation locally, there is also a script for that:
+!!! note
+    We support various tools for developers.
+    Select your preferred one from the tabs below.
+    If you don't know `uv` or Hatch, stick with the default for now.
 
-    hatch run docs:build
+=== "Default"
 
-### Pre-commit
+    The "default" approach to developing is to install the development extras in your current environment:
 
-You can install the [pre-commit](https://pre-commit.com/) hooks with:
+        pip install -e .[pre-commit,tests,docs]
 
-    hatch run precommit:install
+    🔧 **Pre-commit**
 
-Or run them via:
+    To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
 
-    hatch run precommit:install
+        pre-commit install
 
-From the extensive [Ruff ruleset](https://docs.astral.sh/ruff/rules/) that Hatch uses, we ignore the following globally:
+    They will then run on every `git commit`.
+    You can also run them on e.g. all files using:
+
+        pre-commit run -a
+
+    Drop the `-a` option in case you only want to run on staged files.
+
+    🧪 **Tests**
+
+    You can run all tests in the `tests` directory with `pytest`:
+
+        pytest
+
+    Or select the test module:
+
+        pytest tests/parsers/test_pw.py
+
+    See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+    📚 **Documentation**
+
+    We use [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) as our documentation framework.
+    Start the documentation server with:
+
+        mkdocs serve
+
+    and open the documentation in your browser via the link shown.
+    Every time you save a file, the corresponding documentation page is updated automatically!
+
+=== "uv"
+
+    `uv` is a Python package and project manager.
+    See [the documentation](https://docs.astral.sh/uv/getting-started/installation/) on how to install `uv`.
+
+    🔧 **Pre-commit**
+
+    To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+        uvx pre-commit install
+
+    They will then run on every `git commit`.
+    You can also run them on e.g. all files using:
+
+        uvx pre-commit run -a
+
+    Drop the `-a` option in case you only want to run on staged files.
+
+    !!! note
+        Here we use the [`uvx` command](https://docs.astral.sh/uv/guides/tools/#running-tools) to run the `pre-commit` tool without installing it.
+        Alternatively you can also install [`pre-commit` as a tool](https://docs.astral.sh/uv/guides/tools/#installing-tools) and omit `uvx`.
+
+    🧪 **Tests**
+
+    You can run all tests in the `tests` directory with `pytest`:
+
+        uv run pytest
+
+    Or select the test module:
+
+        uv run pytest tests/parsers/test_pw.py
+
+    See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+    📚 **Documentation**
+
+    We use [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) as our documentation framework.
+    Start the documentation server with:
+
+        mkdocs serve
+
+    and open the documentation in your browser via the link shown.
+    Every time you save a file, the corresponding documentation page is updated automatically!
+
+=== "Hatch"
+
+    You can use [Hatch](https://hatch.pypa.io/1.9/install/) to run development tools in isolated environments.
+    To see a table of the available environments and their scripts, run:
+
+        hatch env show
+
+    🔧 **Pre-commit**
+
+    To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+        hatch run pre-commit:install
+
+    They will then run on every `git commit`.
+    You can also run them on e.g. all files using:
+
+        hatch run pre-commit:run -a
+
+    Drop the `-a` option in case you only want to run on staged files.
+
+    🧪 **Tests**
+
+    You can run all tests in the `tests` directory using:
+
+        hatch test
+
+    Or select the test module:
+
+        hatch test tests/parsers/test_pw.py
+
+    You can also run the tests for a specific Python version with the `-py` option:
+
+        hatch test -py 3.11
+
+    Or all supported Python `versions` with `--all`:
+
+        hatch test --all
+
+    See the [Hatch documentation](https://hatch.pypa.io/1.12/tutorials/testing/overview/) for more information.
+
+    📚 **Documentation**
+
+    We use [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) as our documentation framework.
+    Start the documentation server with:
+
+        hatch run docs:serve
+
+    and open the documentation in your browser via the link shown.
+    Every time you save a file, the corresponding documentation page is updated automatically!
+
+
+## Pre-commit rules
+
+From the extensive [Ruff ruleset](https://docs.astral.sh/ruff/rules/), we ignore the following globally:
 
 | Code      | Rule                                                                                                                      | Rationale / Note                                                                                                                    |
 | --------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
@@ -45,10 +174,3 @@ And the following rules for the files in the `tests` directory:
 | --------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `INP001`  | [implicit-namespace-package](https://docs.astral.sh/ruff/rules/implicit-namespace-package/)                               | When tests are not part of the package, there is no need for `__init__.py` files.                                                   |
 | `S101`    | [assert](https://docs.astral.sh/ruff/rules/assert/)                                                                       | Asserts should not be used in production environments, but are fine for tests.                                                      |
-
-### Tests
-
-Tests are written using the [`pytest` package](https://docs.pytest.org/en/stable/index.html).
-They can be run using:
-
-    hatch run tests:run

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ theme:
 
 markdown_extensions:
   - admonition
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
 
 nav:
   - index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,26 +36,51 @@ dependencies = [
 Home = 'https://github.com/aiidateam/qe-tools'
 Source = 'https://github.com/aiidateam/qe-tools'
 
+[project.optional-dependencies]
+docs = [
+"mkdocs",
+  "mkdocs-material"
+]
+tests = [
+  "pytest",
+  "pytest_cases",
+  "timeout_decorator",
+  "pytest-regressions"
+]
+pre-commit = [
+  "pre-commit"
+]
+
+[dependency-groups]
+dev = [
+  "qe-tools[docs,tests,pre-commit]",
+]
+
 [tool.hatch.version]
 path = "src/qe_tools/__about__.py"
 
+[tool.hatch.envs.default]
+installer = 'uv'
+
 [tool.hatch.envs.docs]
-dependencies = [
-  "mkdocs",
-  "mkdocs-material"
-]
+features = ["docs"]
 scripts.build = "mkdocs build --clean --strict"
 scripts.serve = "mkdocs serve --dev-addr localhost:8000"
 scripts.deploy = "mkdocs gh-deploy --force"
 
-[tool.hatch.envs.precommit]
-dependencies = ["pre-commit"]
+[tool.hatch.envs.pre-commit]
+features = ["pre-commit"]
 scripts.install = "pre-commit install"
-scripts.run = "pre-commit run {args:--all-files}"
+scripts.run = "pre-commit run {args}"
 
-[tool.hatch.envs.tests]
-dependencies = ["pytest", "pytest_cases", "timeout_decorator", "pytest-regressions"]
-scripts.run = "pytest {args}"
+[tool.hatch.envs.hatch-test]
+features = ["tests"]
+randomize = false
+parallel = false
+run = "pytest {args}"
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.ruff]
 lint.ignore = [


### PR DESCRIPTION
Adapt the `pyproject.toml` to allow more options for development besides Hatch:

1. add extras for the various developer operations: `pre-commit`, `tests` and `docs`.
2. add the `dev` dependency group, which `uv` uses by default in its environments.

To support these options, adapt the pre-commit configuration to run the Ruff hook directly from their repository.

Improve the Hatch environments, most importantly adapt the `test` environment so we can run `hatch test` for different Python versions or all supported ones.

See the release for more details:

https://github.com/mbercx/python-copier/releases/tag/v0.11.0