### PR TITLE
🐛 `PwOutput.from_dir`: improve XML path finding

### DIFF
--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -27,12 +27,9 @@ class PwOutput(BaseOutput):
             raise ValueError(f"Path `{directory}` is not a valid directory.")
 
         stdout_file = None
-        xml_file = None
+        xml_file = next(directory.rglob("data-file*.xml"))
 
         for file in [path for path in directory.iterdir() if path.is_file()]:
-            if file.suffix == ".xml":
-                xml_file = file
-
             with file.open("r") as handle:
                 header = "".join(handle.readlines(5))
 


### PR DESCRIPTION
The current approach for finding the XML file assumes it is in the top-level directory. However, in case the user specifies the `outdir` input, this is no longer the case. Here we adapt the `from_dir` method to recursively look for the `data-file.xml`/`data-file-schema.xml` file.