### PR TITLE
📦 Remove `scipy` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 ]
 dependencies = [
     'numpy',
-    'scipy',
     'packaging',
     'xmlschema',
 ]


### PR DESCRIPTION
`scipy` - a massive package to have a dependency - was for some reason only used to calculate the norm of a vector. This functionality is also in the `numpy.linalg` module, and so we can remove `scipy` as a dependency.