### PR TITLE
👌 `BaseOutput`: rename `outputs` to `raw_outputs`

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ from qe_tools.outputs import PwOutput
 qe_dir = '/Users/mbercx/project/qetools/data/qe_dir'
 
 pw_out = PwOutput.from_dir(qe_dir)
-pw_out.outputs
+pw_out.raw_outputs
 ```
 
 ## Parsing a single output file

--- a/src/qe_tools/outputs/base.py
+++ b/src/qe_tools/outputs/base.py
@@ -10,8 +10,8 @@ class BaseOutput(abc.ABC):
     Abstract class for the outputs of Quantum ESPRESSO.
     """
 
-    def __init__(self, outputs: dict | None = None):
-        self.outputs = outputs
+    def __init__(self, raw_outputs: dict):
+        self.raw_outputs = raw_outputs
 
     @classmethod
     @abc.abstractmethod

--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -12,9 +12,6 @@ from qe_tools.outputs.parsers.pw import PwStdoutParser, PwXMLParser
 class PwOutput(BaseOutput):
     """Output of the Quantum ESPRESSO pw.x code."""
 
-    def __init__(self, outputs: dict | None = None):
-        super().__init__(outputs=outputs)
-
     @classmethod
     def from_dir(cls, directory: str | Path):
         """
@@ -46,16 +43,16 @@ class PwOutput(BaseOutput):
         stdout: None | str | Path | TextIO = None,
     ):
         """Parse the outputs directly from the provided files."""
-        outputs = {}
+        raw_outputs = {}
 
         if stdout is not None:
             parser_std = PwStdoutParser.from_file(stdout)
             parser_std.parse()
-            outputs |= parser_std.dict_out
+            raw_outputs |= parser_std.dict_out
 
         if xml is not None:
             parser_xml = PwXMLParser.from_file(xml)
             parser_xml.parse()
-            outputs |= parser_xml.dict_out
+            raw_outputs |= parser_xml.dict_out
 
-        return cls(outputs=outputs)
+        return cls(raw_outputs=raw_outputs)

--- a/tests/outputs/test_pw_output.py
+++ b/tests/outputs/test_pw_output.py
@@ -31,6 +31,6 @@ def test_default_xml(data_regression, xml_format):
 
     data_regression.check(
         {
-            "outputs": pw_out.outputs,
+            "outputs": pw_out.raw_outputs,
         }
     )


### PR DESCRIPTION
Partially fixes https://github.com/aiidateam/qe-tools/issues/98

The current `outputs` input of the `BaseOutput` constructor contains all the "raw" parsed data, which is a very large dictionary. This typically is not what a user would want.

In preparation for a more user-friendly approach, we rename the `outputs` class variable to `raw_outputs`, making the expected contents more clear.

We also adapt the `BaseOutput` constructor to _require_ the `raw_outputs` input argument; instantiating the class without it does not make much sense at the moment. Moreover, the `PwOutput` defines its own constructor, but the only thing it does is call the parent one. Hence we can just remove it.