### PR TITLE
✨ `BaseOutput`: add `get_output_from_spec` method

### DIFF
--- a/docs/design/outputs.md
+++ b/docs/design/outputs.md
@@ -130,6 +130,25 @@ Having a string as an input is not the most user-friendly:
 
 These issues will be addressed in future work.
 
+## Custom spec
+
+In order to give users more power and freedom to users, we want them to be able to write their own custom spec to get the outputs they are interested in.
+Note that they could already do this quite easily:
+
+```
+from glom import glom
+
+glom(pw_out.raw_outputs, 'xml.output.magnetization.absolute')
+```
+
+But in order to make this _even more_ accessible, we add a `BaseOutput.get_output_from_spec()` method:
+
+```
+pw_out.get_output_from_spec('xml.output.magnetization.absolute')
+```
+
+Which does _exactly_ the same thing.
+
 ## Other codes than `pw.x`:
 
 How to support multiple "raw" outputs? (i.e. for the various codes?)

--- a/src/qe_tools/outputs/base.py
+++ b/src/qe_tools/outputs/base.py
@@ -1,6 +1,7 @@
 """Base parser for the outputs of Quantum ESPRESSO."""
 
 from __future__ import annotations
+from glom import glom
 
 import abc
 
@@ -17,3 +18,7 @@ class BaseOutput(abc.ABC):
     @abc.abstractmethod
     def from_dir(cls, directory: str):
         pass
+
+    def get_output_from_spec(self, spec):
+        """Extract data from the "raw" outputs using a `glom` specification."""
+        return glom(self.raw_outputs, spec)

--- a/tests/outputs/test_base.py
+++ b/tests/outputs/test_base.py
@@ -1,0 +1,34 @@
+from textwrap import dedent
+
+import pytest
+import yaml
+
+# Note: we use and import the PwOutput class here, because we can't instantiate the
+# abstract base class BaseOutput. But we are testing the methods of that class here.
+from qe_tools.outputs.pw import PwOutput
+
+
+@pytest.fixture
+def raw_outputs():
+    return yaml.safe_load(
+        dedent(
+            """
+            a: 1
+            b:
+                c: 3
+                d: 4
+            """
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("spec", "result"),
+    [
+        ("a", 1),
+        ("b.c", 3),
+        ("b", {"c": 3, "d": 4}),
+    ],
+)
+def test_get_output_from_spec(raw_outputs, spec, result):
+    assert result == PwOutput(raw_outputs).get_output_from_spec(spec)


### PR DESCRIPTION
A common use case is that we might not support parsing for a certain output (yet). Or users want to get the output in a different structure/format. In principle, they can already do this quite easily using `glom` and the `raw_output`. But to make this option more accessible and findable, we add a `get_output_from_spec` method that exactly uses the provided `spec` input to extract data from the `raw_output` with `glom`.