### PR TITLE
✨ Parsers: make classes stateless

### DIFF
--- a/docs/design/outputs.md
+++ b/docs/design/outputs.md
@@ -11,7 +11,39 @@ Below is a rough schematic of how the current implementation works:
 
 ## One file, one parser class
 
-All the logic related to parsing (or generating) a file should be stored on one class, with possibly some generic utility methods shared between parser classes.
+All the logic related to parsing (or generating) a file should be stored on one class, with generic utility methods shared between parser classes.
+The parser classes are implemented as stateless objects, which have to implement a single `parse`
+method with the following signature:
+
+```python
+def parse(content: str):
+
+    parsed_data: dict = ...
+    return parsed_data
+```
+
+This make their usage and implementation very transparent. Moreover, it means we can
+obtain the parsed data in a single step, e.g.:
+
+```python
+parsed_data = PwXMLParser.parse(content)
+```
+
+The abstract base class `BaseOutputFileParser` also implements a `parse_from_file` method that all parser classes can use:
+
+```python
+parsed_data = PwXMLParser.parse_from_file('qe_dir/pwscf.xml')
+```
+
+!!! note
+
+    One motivation for having a stateful class might be performance: by storing the raw content on the class and only parsing it later, we can selectively parse what is needed.
+    However, parsing the XML is most likely the most expensive operation we'll have to do here, in part because of the validation done by `xmlschema`.
+    We're not sure if partially parsing the XML is an option, or we would lose the validation.
+    There is also no performance bottleneck at this stage, even for larger XML files the parsing only takes 50 ms.
+
+    Since the parser classes are not part of the public API at this point (see below), we can still come back on this point at a later date.
+    Moreover, we can still keep the static methods in place, i.e. make changes to support partial parsing in a backwards-compatible manner.
 
 !!! question "Should the file parser classes be part of the public API?"
 

--- a/src/qe_tools/outputs/parsers/base.py
+++ b/src/qe_tools/outputs/parsers/base.py
@@ -19,12 +19,9 @@ class BaseOutputFileParser(abc.ABC):
     should therefore require multiple parsers.
     """
 
-    def __init__(self, string: str):
-        self.string = string
-        self.dict_out: dict = {}
-
+    @staticmethod
     @abc.abstractmethod
-    def parse(self):
+    def parse(content: str):
         """
         Parse the output of Quantum ESPRESSO.
         This should be implemented for XML and standard output,
@@ -33,27 +30,28 @@ class BaseOutputFileParser(abc.ABC):
         """
 
     @classmethod
-    def from_file(cls, file: str | Path | TextIO):
+    def parse_from_file(cls, file: str | Path | TextIO):
         """
         Helper function to generate a BaseOutputFileParser object
         from a file instead of its string.
         """
         if isinstance(file, (str, Path)):
             with Path(file).open("r") as handle:
-                contents = handle.read()
+                content = handle.read()
         elif isinstance(file, TextIOBase):
-            contents = file.read()
+            content = file.read()
         else:
             raise TypeError(f"Unsupported type: {type(file)}")
 
-        return cls(string=contents)
+        return cls.parse(content)
 
 
 class BaseStdoutParser(BaseOutputFileParser):
     """Abstract class for the parsing of stdout files of Quantum ESPRESSO."""
 
-    def parse(self):
-        """Parse the ``stdout`` content of a Quantum ESPRESSO calculation.
+    @staticmethod
+    def parse(content):
+        """Parse the basic ``stdout`` content of a Quantum ESPRESSO calculation.
 
         This function only checks for basic content like the code name and version,
         as well as the wall time of the calculation.
@@ -64,7 +62,7 @@ class BaseStdoutParser(BaseOutputFileParser):
 
         code_match = re.search(
             r"Program\s(?P<code_name>[A-Za-z\_\d]+)\sv\.(?P<code_version>[\d\.a-zA-Z]+)\s",
-            self.string,
+            content,
         )
         if code_match:
             code_name = code_match.groupdict()["code_name"]
@@ -72,12 +70,11 @@ class BaseStdoutParser(BaseOutputFileParser):
 
             wall_match = re.search(
                 rf"{code_name}\s+:[\s\S]+CPU\s+(?P<wall_time>[\s.\dsmdh]+)\sWALL",
-                self.string,
+                content,
             )
-
             if wall_match:
                 parsed_data["wall_time_seconds"] = convert_qe_time_to_sec(
                     wall_match.groupdict()["wall_time"]
                 )
 
-        self.dict_out |= parsed_data
+        return parsed_data

--- a/src/qe_tools/outputs/parsers/pw.py
+++ b/src/qe_tools/outputs/parsers/pw.py
@@ -14,13 +14,11 @@ class PwXMLParser(BaseOutputFileParser):
     Class for parsing the XML output of pw.x.
     """
 
-    def __init__(self, string: str):
-        super().__init__(string=string)
-
-    def parse(self):
+    @staticmethod
+    def parse(content):
         """Parse the XML output of Quantum ESPRESSO pw.x."""
 
-        element_root = ElementTree.fromstring(self.string)
+        element_root = ElementTree.fromstring(content)
 
         str_filename = element_root.get(
             "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation"
@@ -43,15 +41,10 @@ class PwXMLParser(BaseOutputFileParser):
         except AttributeError:
             pass
 
-        self.dict_out["xml"] = XMLSchema(str(files(schemas) / schema_filename)).to_dict(
-            element_root
-        )
+        return XMLSchema(str(files(schemas) / schema_filename)).to_dict(element_root)
 
 
 class PwStdoutParser(BaseStdoutParser):
     """
     Class for parsing the standard output of pw.x.
     """
-
-    def __init__(self, string: str):
-        super().__init__(string=string)

--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -46,14 +46,10 @@ class PwOutput(BaseOutput):
         raw_outputs = {}
 
         if stdout is not None:
-            parser_std = PwStdoutParser.from_file(stdout)
-            parser_std.parse()
-            raw_outputs |= parser_std.dict_out
+            raw_outputs = PwStdoutParser.parse_from_file(stdout)
 
         if xml is not None:
-            parser_xml = PwXMLParser.from_file(xml)
-            parser_xml.parse()
-            raw_outputs |= parser_xml.dict_out
+            raw_outputs["xml"] = PwXMLParser.parse_from_file(xml)
 
         return cls(raw_outputs=raw_outputs)
 


### PR DESCRIPTION
In the current implementation, we need to

1. instantiate a parser class.
2. run the `.parse()` method on the `string` content.
3. extract the raw outputs from the `dict_out` attribute.

However, there is no need to store any data on a parser class. Instead, we can convert the parser classes into stateless objects, which have to implement a single `parse` method with the following signature:

   def parse(content: str):

      parsed_data: dict = ...
      return parsed_data

This make their usage and implementation more transparent: no more `dict_out` attribute that suddenly appears in the `parse` method of a child class. Moreover, it means we can obtain the parsed data in a single step, e.g.:

     parsed_data = PwXMLParser.parse(content)

One motivation for having a stateful class might be performance: by storing the raw content on the class and only parsing it later, we can selectively parse what is needed. However, parsing the XML is most likely the most expensive operation we'll have to do here, in part because of the validation done by `xmlschema`. We're not sure if partially parsing the XML is an option, or we would lose the validation. There is also no performance bottleneck at this stage, even for larger XML files the parsing only takes 50 ms.

Since the parser classes are not part of the public API at this point, we can still come back on this point at a later date. Moreover, we can still keep the static methods in place, i.e. make changes to support partial parsing in a backwards-compatible manner.

Finally, we rename the `string` input to `content`, which is of type `str`.