### PR TITLE
👌 `PwOutput`: move `stdout` into separate key in `raw_output`

### DIFF
--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -46,7 +46,7 @@ class PwOutput(BaseOutput):
         raw_outputs = {}
 
         if stdout is not None:
-            raw_outputs = PwStdoutParser.parse_from_file(stdout)
+            raw_outputs["stdout"] = PwStdoutParser.parse_from_file(stdout)
 
         if xml is not None:
             raw_outputs["xml"] = PwXMLParser.parse_from_file(xml)

--- a/tests/outputs/test_pw_output/test_default_xml_211101_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_211101_.yml
@@ -1,7 +1,8 @@
 fermi_energy: 0.2681470452273149
 outputs:
-  code_version: '7.0'
-  wall_time_seconds: 1.96
+  stdout:
+    code_version: '7.0'
+    wall_time_seconds: 1.96
   xml:
     '@Units': Hartree atomic units
     '@{http://www.w3.org/2001/XMLSchema-instance}schemaLocation': http://www.quantum-espresso.org/ns/qes/qes-1.0

--- a/tests/outputs/test_pw_output/test_default_xml_220603_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_220603_.yml
@@ -1,7 +1,8 @@
 fermi_energy: 0.2454594023920023
 outputs:
-  code_version: '7.1'
-  wall_time_seconds: 2.02
+  stdout:
+    code_version: '7.1'
+    wall_time_seconds: 2.02
   xml:
     '@Units': Hartree atomic units
     '@{http://www.w3.org/2001/XMLSchema-instance}schemaLocation': http://www.quantum-espresso.org/ns/qes/qes-1.0

--- a/tests/outputs/test_pw_output/test_default_xml_230310_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_230310_.yml
@@ -1,7 +1,8 @@
 fermi_energy: 0.3341310716080565
 outputs:
-  code_version: '7.2'
-  wall_time_seconds: 100.44
+  stdout:
+    code_version: '7.2'
+    wall_time_seconds: 100.44
   xml:
     '@Units': Hartree atomic units
     '@{http://www.w3.org/2001/XMLSchema-instance}schemaLocation': http://www.quantum-espresso.org/ns/qes/qes-1.0

--- a/tests/outputs/test_pw_output/test_default_xml_240411_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_240411_.yml
@@ -1,7 +1,8 @@
 fermi_energy: 0.2382326174337512
 outputs:
-  code_version: 7.3.1
-  wall_time_seconds: 2.51
+  stdout:
+    code_version: 7.3.1
+    wall_time_seconds: 2.51
   xml:
     '@Units': Hartree atomic units
     '@{http://www.w3.org/2001/XMLSchema-instance}schemaLocation': http://www.quantum-espresso.org/ns/qes/qes-1.0


### PR DESCRIPTION
In accordance with our intended design, we want to clearly separate the raw output from the various files in their own dictionary key. This also makes the `glom` spec more transparent, since it's easy to see which file the raw data is queried from.