### PR TITLE
🔄 `BaseOutput`: Make converter dispatch QE-agnostic

### DIFF
--- a/src/qe_tools/converters/aiida.py
+++ b/src/qe_tools/converters/aiida.py
@@ -1,67 +1,67 @@
 from __future__ import annotations
 
-import numpy as np
+import typing
 
 from glom import T
+
 from qe_tools.converters.base import BaseConverter
-
-try:
-    from aiida import orm
-except ImportError:
-    raise ModuleNotFoundError(
-        "Unable to import the 'aiida.orm' module.\n"
-        "Consider (re)installing 'qe-tools` with the 'aiida' extra:\n\n"
-        "  pip install qe-tools[aiida]"
-    ) from None
-
-
-def _convert_structure_data(cell, symbols, positions):
-    structure = orm.StructureData(cell=cell)
-
-    for symbol, position in zip(symbols, positions):
-        structure.append_atom(position=position, symbols=symbol)
-
-    return structure
-
-
-def _convert_dos(energy: list, dos: list | dict):
-    xy_data = orm.XyData()
-    xy_data.set_x(np.array(energy), "energy", "eV")
-    if isinstance(dos, dict):
-        xy_data.set_y(
-            [np.array(dos["dos_down"]), np.array(dos["dos_up"])],
-            ["dos_spin_down", "dos_spin_down"],
-            ["states/eV", "states/eV"],
-        )
-    else:
-        xy_data.set_y(np.array(dos), "dos", "states/eV")
-
-    return xy_data
 
 
 class AiiDAConverter(BaseConverter):
-    conversion_mapping = {
-        "structure": (
-            _convert_structure_data,
-            {
-                "symbols": "atomic_species",
-                "cell": ("cell", lambda cell: np.array(cell)),
-                "positions": ("positions", lambda positions: np.array(positions)),
-            },
-        ),
-        "full_dos": (
-            _convert_dos,
-            {
-                "energy": "energy",
-                "dos": (
-                    T,
-                    lambda full_dos: full_dos["dos"]
-                    if "dos" in full_dos
-                    else {
-                        "dos_down": full_dos["dos_down"],
-                        "dos_up": full_dos["dos_up"],
-                    },
-                ),
-            },
-        ),
-    }
+    @classmethod
+    def get_conversion_mapping(cls) -> dict[str, typing.Any]:
+        import numpy as np
+
+        try:
+            from aiida import orm
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Unable to import the 'aiida.orm' module.\n"
+                "Consider (re)installing 'qe-tools` with the 'aiida' extra:\n\n"
+                "  pip install qe-tools[aiida]"
+            ) from None
+
+        def convert_structure_data(cell, symbols, positions):
+            structure = orm.StructureData(cell=cell)
+            for symbol, position in zip(symbols, positions):
+                structure.append_atom(position=position, symbols=symbol)
+            return structure
+
+        def convert_dos(energy: list, dos: list | dict):
+            xy_data = orm.XyData()
+            xy_data.set_x(np.array(energy), "energy", "eV")
+            if isinstance(dos, dict):
+                xy_data.set_y(
+                    [np.array(dos["dos_down"]), np.array(dos["dos_up"])],
+                    ["dos_spin_down", "dos_spin_down"],
+                    ["states/eV", "states/eV"],
+                )
+            else:
+                xy_data.set_y(np.array(dos), "dos", "states/eV")
+            return xy_data
+
+        return {
+            "structure": (
+                convert_structure_data,
+                {
+                    "symbols": "atomic_species",
+                    "cell": ("cell", lambda cell: np.array(cell)),
+                    "positions": ("positions", lambda positions: np.array(positions)),
+                },
+            ),
+            "full_dos": (
+                convert_dos,
+                {
+                    "energy": "energy",
+                    "dos": (
+                        T,
+                        lambda full_dos: full_dos["dos"]
+                        if "dos" in full_dos
+                        else {
+                            "dos_down": full_dos["dos_down"],
+                            "dos_up": full_dos["dos_up"],
+                        },
+                    ),
+                },
+            ),
+        }

--- a/src/qe_tools/converters/ase.py
+++ b/src/qe_tools/converters/ase.py
@@ -1,27 +1,31 @@
 from __future__ import annotations
 
-import numpy as np
+import typing
 
 from qe_tools.converters.base import BaseConverter
 
-try:
-    from ase import Atoms
-except ImportError:
-    raise ModuleNotFoundError(
-        "Unable to import from the 'ase' library.\n"
-        "Consider (re)installing 'qe-tools` with the 'ase' extra:\n\n"
-        "  pip install qe-tools[ase]"
-    ) from None
-
 
 class ASEConverter(BaseConverter):
-    conversion_mapping = {
-        "structure": (
-            Atoms,
-            {
-                "symbols": "symbols",
-                "cell": ("cell", lambda cell: np.array(cell)),
-                "positions": ("positions", lambda positions: np.array(positions)),
-            },
-        ),
-    }
+    @classmethod
+    def get_conversion_mapping(cls) -> dict[str, typing.Any]:
+        import numpy as np
+
+        try:
+            from ase import Atoms
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Unable to import from the 'ase' library.\n"
+                "Consider (re)installing 'qe-tools` with the 'ase' extra:\n\n"
+                "  pip install qe-tools[ase]"
+            ) from None
+
+        return {
+            "structure": (
+                Atoms,
+                {
+                    "symbols": "symbols",
+                    "cell": ("cell", lambda cell: np.array(cell)),
+                    "positions": ("positions", lambda positions: np.array(positions)),
+                },
+            ),
+        }

--- a/src/qe_tools/converters/base.py
+++ b/src/qe_tools/converters/base.py
@@ -4,11 +4,19 @@ from glom import glom
 
 
 class BaseConverter:
-    conversion_mapping: typing.ClassVar[dict[str, typing.Any]]
+    @classmethod
+    def get_conversion_mapping(cls) -> dict[str, typing.Any]:
+        """Return the conversion mapping for this converter.
+
+        Subclasses override this to build their mapping lazily. Imports from optional
+        dependencies belong inside this method so that simply importing the converter
+        class does not pull them in.
+        """
+        raise NotImplementedError
 
     @classmethod
     def convert(cls, output: str, base_output: dict):
-        output_converter, output_spec = cls.conversion_mapping[output]
+        output_converter, output_spec = cls.get_conversion_mapping()[output]
 
         arguments = glom(base_output, output_spec)
 

--- a/src/qe_tools/converters/pymatgen.py
+++ b/src/qe_tools/converters/pymatgen.py
@@ -1,27 +1,31 @@
 from __future__ import annotations
 
-import numpy as np
+import typing
 
 from qe_tools.converters.base import BaseConverter
 
-try:
-    from pymatgen.core.structure import Structure
-except ImportError:
-    raise ModuleNotFoundError(
-        "Unable to import from the 'pymatgen' library.\n"
-        "Consider (re)installing 'qe-tools` with the 'pymatgen' extra:\n\n"
-        "  pip install qe-tools[pymatgen]"
-    ) from None
-
 
 class PymatgenConverter(BaseConverter):
-    conversion_mapping = {
-        "structure": (
-            Structure,
-            {
-                "species": "symbols",
-                "lattice": ("cell", lambda cell: np.array(cell)),
-                "coords": ("positions", lambda positions: np.array(positions)),
-            },
-        ),
-    }
+    @classmethod
+    def get_conversion_mapping(cls) -> dict[str, typing.Any]:
+        import numpy as np
+
+        try:
+            from pymatgen.core.structure import Structure
+        except ImportError:
+            raise ModuleNotFoundError(
+                "Unable to import from the 'pymatgen' library.\n"
+                "Consider (re)installing 'qe-tools` with the 'pymatgen' extra:\n\n"
+                "  pip install qe-tools[pymatgen]"
+            ) from None
+
+        return {
+            "structure": (
+                Structure,
+                {
+                    "species": "symbols",
+                    "lattice": ("cell", lambda cell: np.array(cell)),
+                    "coords": ("positions", lambda positions: np.array(positions)),
+                },
+            ),
+        }

--- a/src/qe_tools/outputs/base.py
+++ b/src/qe_tools/outputs/base.py
@@ -10,8 +10,7 @@ from functools import cached_property
 
 from glom import glom, GlomError, Spec
 
-if typing.TYPE_CHECKING:
-    from qe_tools.converters.base import BaseConverter
+from qe_tools.converters.base import BaseConverter
 
 
 T = typing.TypeVar("T")
@@ -90,6 +89,18 @@ def output_mapping(cls):
 class BaseOutput(abc.ABC, typing.Generic[T]):
     """Abstract base class for the outputs of Quantum ESPRESSO."""
 
+    converters: typing.ClassVar[dict[str, type[BaseConverter]]] = {}
+    """Mapping of target-library name to its `BaseConverter` subclass.
+
+    Subclasses populate this with the converters they support, e.g.
+
+        `converters = {"ase": ASEConverter, ...}`
+
+    Each converter is responsible for importing optional dependencies lazily inside the
+    `get_conversion_mapping()` classmethod, so simply listing it here does not pull it
+    in at import time.
+    """
+
     @classmethod
     def _get_mapping_class(cls) -> type:
         """Extract the mapping class from the generic parameter.
@@ -144,16 +155,21 @@ class BaseOutput(abc.ABC, typing.Generic[T]):
         """
         return glom(self.raw_outputs, spec)
 
-    def get_output(
-        self, name: str, to: typing.Literal["aiida", "ase", "pymatgen"] | None = None
-    ):
+    def get_output(self, name: str, to: str | None = None):
         """Return an output by `name`.
 
         Args:
             name (str): Output to retrieve (e.g., "structure", "fermi_energy",
                 "forces").
-            to (str): Optional target library to convert the base output to. One of
-                "aiida", "ase", "pymatgen".
+            to (str): Optional target library to convert the base output to.
+
+                The supported values are the keys of this subclass's `converters`
+                class variable — list them with
+
+                    `sorted(OutputClass.converters)`
+
+                Passing an unsupported value raises `ValueError` listing the
+                available options.
 
         Examples:
             >>> pw_out.get_output(name="structure")
@@ -173,44 +189,49 @@ class BaseOutput(abc.ABC, typing.Generic[T]):
         if to is None:
             return output_data
 
-        # Pre-declare so the three lazy imports below don't trip mypy `no-redef`.
-        Converter: type[BaseConverter]
+        try:
+            Converter = self.converters[to]
+        except KeyError:
+            available = sorted(self.converters)
+            raise ValueError(
+                f"Library '{to}' is not supported. Available: {available}"
+            ) from None
 
-        if to == "aiida":
-            from qe_tools.converters.aiida import AiiDAConverter as Converter
-        elif to == "ase":
-            from qe_tools.converters.ase import ASEConverter as Converter
-        elif to == "pymatgen":
-            from qe_tools.converters.pymatgen import PymatgenConverter as Converter
-        else:
-            raise ValueError(f"Library '{to}' is not supported.")
+        conversion_mapping = Converter.get_conversion_mapping()
 
         if isinstance(entry, dict):
             return {
                 sub_name: Converter().convert(f"{name}.{sub_name}", sub_value)
-                if sub_name in Converter.conversion_mapping
+                if sub_name in conversion_mapping
                 else sub_value
                 for sub_name, sub_value in output_data.items()
             }
 
         return (
             Converter().convert(name, output_data)
-            if name in Converter.conversion_mapping
+            if name in conversion_mapping
             else output_data
         )
 
     def get_output_dict(
         self,
         names: None | list[str] = None,
-        to: typing.Literal["aiida", "ase", "pymatgen"] | None = None,
+        to: str | None = None,
     ) -> dict:
         """Return a dictionary of outputs.
 
         Args:
             names (list[str]): Output names to include. If not provided, all
                 available outputs are included.
-            to (str): Optional target library to convert each output to. One of
-                "aiida", "ase", "pymatgen".
+            to (str): Optional target library to convert the base output to.
+
+                The supported values are the keys of this subclass's `converters`
+                class variable — list them with
+
+                    `sorted(OutputClass.converters)`
+
+                Passing an unsupported value raises `ValueError` listing the
+                available options.
 
         Returns:
             dict: Mapping from output name to value.

--- a/src/qe_tools/outputs/dos.py
+++ b/src/qe_tools/outputs/dos.py
@@ -1,10 +1,15 @@
 """Output of the Quantum ESPRESSO dos.x code."""
 
+import typing
 from pathlib import Path
 from typing import TextIO
 
 from glom import Spec
 
+from qe_tools.converters.aiida import AiiDAConverter
+from qe_tools.converters.ase import ASEConverter
+from qe_tools.converters.base import BaseConverter
+from qe_tools.converters.pymatgen import PymatgenConverter
 from qe_tools.outputs.base import BaseOutput, output_mapping
 
 from .parsers.base import BaseStdoutParser
@@ -53,6 +58,12 @@ class _DosMapping:
 
 class DosOutput(BaseOutput[_DosMapping]):
     """Output of the Quantum ESPRESSO dos.x code."""
+
+    converters: typing.ClassVar[dict[str, type[BaseConverter]]] = {
+        "ase": ASEConverter,
+        "pymatgen": PymatgenConverter,
+        "aiida": AiiDAConverter,
+    }
 
     @classmethod
     def from_dir(cls, directory: str | Path):

--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -1,11 +1,16 @@
 """Output of the Quantum ESPRESSO pw.x code."""
 
 import math
+import typing
 from pathlib import Path
 from typing import TextIO
 
 from glom import Coalesce, Spec
 
+from qe_tools.converters.aiida import AiiDAConverter
+from qe_tools.converters.ase import ASEConverter
+from qe_tools.converters.base import BaseConverter
+from qe_tools.converters.pymatgen import PymatgenConverter
 from qe_tools.outputs.base import BaseOutput, output_mapping
 from qe_tools.outputs.parsers.pw import PwStdoutParser, PwXMLParser
 
@@ -247,6 +252,12 @@ class _PwMapping:
 
 class PwOutput(BaseOutput[_PwMapping]):
     """Output of the Quantum ESPRESSO pw.x code."""
+
+    converters: typing.ClassVar[dict[str, type[BaseConverter]]] = {
+        "ase": ASEConverter,
+        "pymatgen": PymatgenConverter,
+        "aiida": AiiDAConverter,
+    }
 
     @classmethod
     def from_dir(cls, directory: str | Path):


### PR DESCRIPTION
`BaseOutput.get_output` previously hard-coded a chain of `if to == "aiida" / "ase" / "pymatgen"` branches with inline lazy imports of QE-specific converter classes. The abstract base was therefore coupled to the concrete set of supported target libraries — a subclass could not declare its own converters without editing `base.py`, and adding a new library meant touching the dispatch site rather than the converter that introduced it. The longer-term goal is for `BaseOutput` to live in a code-agnostic core that knows nothing about QE-specific converters.

Replace the dispatch with a `converters` class variable on `BaseOutput`, typed `dict[str, type[BaseConverter]]` and empty by default. Subclasses (`PwOutput`, `DosOutput`) populate it with the converter classes they support. `get_output` looks the entry up directly: a `KeyError` is translated into a `ValueError` listing the available options for that specific subclass, so the error message is now driven by what the subclass actually advertises rather than a hard-coded literal. The `to` parameter is widened from `Literal["aiida", "ase", "pymatgen"]` to plain `str` for the same reason.

This widening is a temporary UX regression: editors and `mypy` no longer autocomplete or validate the set of valid `to=` values at the call site, and a typo like `to="asee"` now surfaces as a runtime `ValueError` rather than a static type error. The plan is to recover the static narrowing on a per-subclass basis via `typing.overload` stubs on `PwOutput.get_output` / `DosOutput.get_output` that declare a `Literal` of exactly that subclass's supported keys, with the runtime implementation still delegating to the `str`-typed base.

Holding direct class references (rather than dotted-path strings) only is possible by deferring the heavy third-party imports one layer down, into the converters themselves. `BaseConverter.conversion_mapping` — previously a class attribute that forced `from ase import Atoms` (and the `pymatgen` / `aiida` equivalents) at module-import time — is replaced by a `get_conversion_mapping()` classmethod. Each subclass imports its heavy dependency inside that method body and returns the mapping built against the just-imported types. The friendly `ModuleNotFoundError` install hint is preserved. As a result, importing `PwOutput` no longer pulls `ase`, `pymatgen`, or `aiida` into `sys.modules` — verified by inspection — so the lazy-loading property the old `if/elif` chain provided is retained without the dispatch.

`BaseOutput.get_output` now resolves the mapping once via `Converter.get_conversion_mapping()` and reuses it for both the sub-namespace dict branch and the leaf branch, instead of accessing `Converter.conversion_mapping` twice as an attribute.