### PR TITLE
🔄 `parsers`: Extract `BaseStdoutParser` to dedicated module

### DIFF
--- a/src/qe_tools/outputs/dos.py
+++ b/src/qe_tools/outputs/dos.py
@@ -12,7 +12,7 @@ from qe_tools.converters.base import BaseConverter
 from qe_tools.converters.pymatgen import PymatgenConverter
 from qe_tools.outputs.base import BaseOutput, output_mapping
 
-from .parsers.base import BaseStdoutParser
+from .parsers.stdout import BaseStdoutParser
 from .parsers.dos import DosParser
 from .parsers.pw import PwXMLParser
 

--- a/src/qe_tools/outputs/parsers/base.py
+++ b/src/qe_tools/outputs/parsers/base.py
@@ -1,33 +1,23 @@
-"""Base parser for the outputs of Quantum ESPRESSO."""
+"""Generic file-parsing base class."""
 
 from __future__ import annotations
 
 import abc
-import re
 from io import TextIOBase
 from pathlib import Path
 from typing import TextIO
 
-from qe_tools.utils import convert_qe_time_to_sec
-
 
 class BaseOutputFileParser(abc.ABC):
     """
-    Abstract class for the parsing of output files of Quantum ESPRESSO.
-    Each parser should parse a single file.
-    A computation with multiple files as outputs (e.g., NEB)
-    should therefore require multiple parsers.
+    Abstract class for parsing a single output file.
+    A computation with multiple output files should therefore define multiple parsers.
     """
 
     @staticmethod
     @abc.abstractmethod
     def parse(content: str):
-        """
-        Parse the output of Quantum ESPRESSO.
-        This should be implemented for XML and standard output,
-        whenever possible, in dedicated objects
-        (e.g., PwStdoutParser and PwXMLParser).
-        """
+        """Parse the file content and return a dictionary of parsed data."""
 
     @classmethod
     def parse_from_file(cls, file: str | Path | TextIO):
@@ -44,37 +34,3 @@ class BaseOutputFileParser(abc.ABC):
             raise TypeError(f"Unsupported type: {type(file)}")
 
         return cls.parse(content)
-
-
-class BaseStdoutParser(BaseOutputFileParser):
-    """Abstract class for the parsing of stdout files of Quantum ESPRESSO."""
-
-    @staticmethod
-    def parse(content):
-        """Parse the basic ``stdout`` content of a Quantum ESPRESSO calculation.
-
-        This function only checks for basic content like the code name and version,
-        as well as the wall time of the calculation.
-
-        :returns: dictionary of the parsed data.
-        """
-        parsed_data = {}
-
-        code_match = re.search(
-            r"Program\s(?P<code_name>[A-Za-z\_\d]+)\sv\.(?P<code_version>[\d\.a-zA-Z]+)\s",
-            content,
-        )
-        if code_match:
-            code_name = code_match.groupdict()["code_name"]
-            parsed_data["code_version"] = code_match.groupdict()["code_version"]
-
-            wall_match = re.search(
-                rf"{code_name}\s+:[\s\S]+CPU\s+(?P<wall_time>[\s.\dsmdh]+)\sWALL",
-                content,
-            )
-            if wall_match:
-                parsed_data["wall_time_seconds"] = convert_qe_time_to_sec(
-                    wall_match.groupdict()["wall_time"]
-                )
-
-        return parsed_data

--- a/src/qe_tools/outputs/parsers/pw.py
+++ b/src/qe_tools/outputs/parsers/pw.py
@@ -6,7 +6,8 @@ from xml.etree import ElementTree
 from xmlschema import XMLSchema
 
 from qe_tools.outputs.parsers import schemas
-from qe_tools.outputs.parsers.base import BaseOutputFileParser, BaseStdoutParser
+from qe_tools.outputs.parsers.base import BaseOutputFileParser
+from qe_tools.outputs.parsers.stdout import BaseStdoutParser
 
 
 class PwXMLParser(BaseOutputFileParser):

--- a/src/qe_tools/outputs/parsers/stdout.py
+++ b/src/qe_tools/outputs/parsers/stdout.py
@@ -1,0 +1,43 @@
+"""Base parser for Quantum ESPRESSO stdout files."""
+
+from __future__ import annotations
+
+import re
+
+from qe_tools.utils import convert_qe_time_to_sec
+
+from .base import BaseOutputFileParser
+
+
+class BaseStdoutParser(BaseOutputFileParser):
+    """Abstract class for the parsing of stdout files of Quantum ESPRESSO."""
+
+    @staticmethod
+    def parse(content):
+        """Parse the basic ``stdout`` content of a Quantum ESPRESSO calculation.
+
+        This function only checks for basic content like the code name and version,
+        as well as the wall time of the calculation.
+
+        :returns: dictionary of the parsed data.
+        """
+        parsed_data = {}
+
+        code_match = re.search(
+            r"Program\s(?P<code_name>[A-Za-z\_\d]+)\sv\.(?P<code_version>[\d\.a-zA-Z]+)\s",
+            content,
+        )
+        if code_match:
+            code_name = code_match.groupdict()["code_name"]
+            parsed_data["code_version"] = code_match.groupdict()["code_version"]
+
+            wall_match = re.search(
+                rf"{code_name}\s+:[\s\S]+CPU\s+(?P<wall_time>[\s.\dsmdh]+)\sWALL",
+                content,
+            )
+            if wall_match:
+                parsed_data["wall_time_seconds"] = convert_qe_time_to_sec(
+                    wall_match.groupdict()["wall_time"]
+                )
+
+        return parsed_data


### PR DESCRIPTION
Move `BaseStdoutParser` from `outputs/parsers/base.py` into a new `outputs/parsers/stdout.py`, so `parsers/base.py` contains only the fully generic `BaseOutputFileParser` and has zero `qe_tools.*` imports or QE references. This is a prerequisite for carving out a generic package: `BaseStdoutParser` is QE-specific (it matches the `Program <NAME> v.X.Y` banner and calls `convert_qe_time_to_sec`), so it does not belong in a code-agnostic base module.

Pure relocation — no behavior changes. Call sites in `parsers/pw.py` (`PwStdoutParser` subclass) and `outputs/dos.py` (direct use for the `dos.x` stdout) are updated to import from the new location.