### PR TITLE
🧪 `tests`: Delegate shared fixtures to `dough.testing` plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'packaging',
     'xmlschema',
     'glom~=24.11',
-    'dough==0.2.1',
+    'dough==0.3.0',
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,39 +1,7 @@
-import pytest
+"""Project-wide pytest fixtures & hooks.
 
-from numpy import ndarray
+Load the `dough.testing` plugin explicitly so `json_serializer` and
+`robust_data_regression_check` are available to the test suite.
+"""
 
-
-@pytest.fixture()
-def robust_data_regression_check(data_regression, json_serializer):
-    """Run a `data_regression.check` call, after converting the data with `json_serializer`."""
-
-    def factory(input):
-        return data_regression.check(json_serializer(input))
-
-    return factory
-
-
-@pytest.fixture()
-def json_serializer():
-    """Fixture for making dictionaries JSON serializable in a robust manner for testing.
-
-    Supported conversions:
-
-        * `numpy.ndarray`; converted into list with `.tolist()`.
-        * `float`/`int`: convert into float rounded to 5 digits.
-    """
-
-    def factory(item):
-        if isinstance(item, (str, bool)):
-            return item
-        if isinstance(item, (list, tuple)):
-            return [factory(el) for el in item]
-        if isinstance(item, dict):
-            return {k: factory(v) for k, v in item.items()}
-        if isinstance(item, (float, int)):
-            return round(float(item), 5)
-        if isinstance(item, ndarray):
-            return factory(item.tolist())
-        raise TypeError(f"Type: '{type(item)}' not supported!")
-
-    return factory
+pytest_plugins = ["dough.testing.plugin"]


### PR DESCRIPTION
`json_serializer` and `robust_data_regression_check` now live in `dough.testing` as an opt-in pytest plugin. Replace the local copies in `tests/conftest.py` with a one-line `pytest_plugins = ["dough.testing.plugin"]` registration, and bump the `dough` pin from `0.2.1` → `0.3.0` in `pyproject.toml` to pick up the new subpackage.

The plugin version of `json_serializer` is a superset of the old qe-tools fixture — same passthrough/rounding/ndarray rules, plus an optional `max_number` kwarg for subsampling large arrays before the regression diff. No call-site changes needed since existing usage passes only the data argument.