### PR TITLE
✨ `PwOutput`: add `wall_time` and `volume` outputs

### DIFF
--- a/src/qe_tools/outputs/parsers/stdout.py
+++ b/src/qe_tools/outputs/parsers/stdout.py
@@ -9,6 +9,11 @@ from dough.outputs import BaseOutputFileParser
 from qe_tools.utils import convert_qe_time_to_sec
 
 
+_VOLUME_RE = re.compile(
+    r"unit-cell volume\s*=\s*([\-\d.E+]+)\s*(?:\(a\.u\.\)|a\.u\.)\^3"
+)
+
+
 class BaseStdoutParser(BaseOutputFileParser):
     """Abstract class for the parsing of stdout files of Quantum ESPRESSO."""
 
@@ -39,5 +44,12 @@ class BaseStdoutParser(BaseOutputFileParser):
                 parsed_data["wall_time_seconds"] = convert_qe_time_to_sec(
                     wall_match.groupdict()["wall_time"]
                 )
+
+        # Initial line: `unit-cell volume          =     275.9279 (a.u.)^3`.
+        # vc-relax also prints `new unit-cell volume = ... a.u.^3 (...)` per step;
+        # take the last match so the final cell volume wins.
+        volume_matches = _VOLUME_RE.findall(content)
+        if volume_matches:
+            parsed_data["volume_bohr3"] = float(volume_matches[-1])
 
         return parsed_data

--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -423,6 +423,16 @@ class _PwMapping:
     ibrav: Annotated[int, Spec("xml.output.atomic_structure.@bravais_index")]
     """Bravais lattice index (QE `ibrav` integer); only present when QE writes it."""
 
+    volume: Annotated[
+        float,
+        Spec(("stdout.volume_bohr3", lambda v: v * CONSTANTS.bohr_to_ang**3)),
+        Unit("angstrom**3"),
+    ]
+    """Unit-cell volume in Å³. For vc-relax runs, the final cell volume."""
+
+    wall_time: Annotated[float, Spec("stdout.wall_time_seconds"), Unit("second")]
+    """Total wall-clock time of the calculation in seconds."""
+
     scf_converged: Annotated[
         bool,
         Spec("xml.output.convergence_info.scf_conv.convergence_achieved"),

--- a/tests/outputs/test_pw_output/test_default_xml_211101_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_211101_.yml
@@ -96,10 +96,13 @@ base_outputs:
     - Si
     - Si
   total_energy: -301.1308454569434
+  volume: 40.888295712459346
+  wall_time: 1.96
 raw_outputs:
   stdout:
     code_version: '7.0'
     total_energy: -22.13271119
+    volume_bohr3: 275.9279
     wall_time_seconds: 1.96
   xml:
     '@Units': Hartree atomic units

--- a/tests/outputs/test_pw_output/test_default_xml_220603_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_220603_.yml
@@ -112,10 +112,13 @@ base_outputs:
     - Si
     - Si
   total_energy: -308.2197480972082
+  volume: 40.888295712459346
+  wall_time: 2.02
 raw_outputs:
   stdout:
     code_version: '7.1'
     total_energy: -22.65373597
+    volume_bohr3: 275.9279
     wall_time_seconds: 2.02
   xml:
     '@Units': Hartree atomic units

--- a/tests/outputs/test_pw_output/test_default_xml_230310_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_230310_.yml
@@ -163,11 +163,14 @@ base_outputs:
     - O
     - Li
   total_energy: -5389.181650709915
+  volume: 32.172248919612365
+  wall_time: 100.44
 raw_outputs:
   stdout:
     code_version: '7.2'
     highest_occupied_level: 9.0922
     total_energy: -396.09758618
+    volume_bohr3: 217.1091
     wall_time_seconds: 100.44
   xml:
     '@Units': Hartree atomic units

--- a/tests/outputs/test_pw_output/test_default_xml_240411_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_240411_.yml
@@ -148,10 +148,13 @@ base_outputs:
     - Si
     - Si
   total_energy: -308.3429884628779
+  volume: 40.367352366109984
+  wall_time: 2.51
 raw_outputs:
   stdout:
     code_version: 7.3.1
     total_energy: -22.66279398
+    volume_bohr3: 272.4124
     wall_time_seconds: 2.51
   xml:
     '@Units': Hartree atomic units

--- a/tests/outputs/test_pw_output/test_default_xml_250521_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_250521_.yml
@@ -147,10 +147,13 @@ base_outputs:
     - Li
     - F
   total_energy: -3437.983896407087
+  volume: 65.45083006209762
+  wall_time: 2.33
 raw_outputs:
   stdout:
     code_version: '7.5'
     total_energy: -252.68718165
+    volume_bohr3: 441.6841
     wall_time_seconds: 2.33
   xml:
     '@Units': Hartree atomic units

--- a/tests/outputs/test_pw_output/test_failed_failed_no_xml_.yml
+++ b/tests/outputs/test_pw_output/test_failed_failed_no_xml_.yml
@@ -1,5 +1,7 @@
 base_outputs:
   parameters: {}
+  volume: 65.45083006209762
 raw_outputs:
   stdout:
     code_version: '7.5'
+    volume_bohr3: 441.6841

--- a/tests/outputs/test_pw_output/test_success_base_collinear_.yml
+++ b/tests/outputs/test_pw_output/test_success_base_collinear_.yml
@@ -110,3 +110,5 @@ base_outputs:
     - Li
     - F
   total_magnetization: 0.0
+  volume: 65.45083006209762
+  wall_time: 6.28


### PR DESCRIPTION
Both are parsed from stdout:

- `wall_time` — final `PWSCF :  ... s CPU  ... s WALL` line; already collected by `BaseStdoutParser` as `wall_time_seconds`, now exposed via a Spec with `Unit("second")`.
- `volume` — `unit-cell volume = ... (a.u.)^3` (and the `new unit-cell volume = ... a.u.^3 (...)` form printed by vc-relax). `BaseStdoutParser` now records the last match as `volume_bohr3`; the Spec converts bohr³ → Å³ via `CONSTANTS.bohr_to_ang**3` and tags `Unit("angstrom**3")`.

The XML schema does not include the cell volume, so stdout is the only source; for vc-relax taking the last match yields the final relaxed volume rather than the initial one.