### PR TITLE
✨ `PwOutput`: Parse `ecutwfc` and `ecutrho` from stdout as fallback

### DIFF
--- a/src/qe_tools/outputs/parsers/stdout.py
+++ b/src/qe_tools/outputs/parsers/stdout.py
@@ -12,6 +12,8 @@ from qe_tools.utils import convert_qe_time_to_sec
 _VOLUME_RE = re.compile(
     r"unit-cell volume\s*=\s*([\-\d.E+]+)\s*(?:\(a\.u\.\)|a\.u\.)\^3"
 )
+_ECUTWFC_RE = re.compile(r"kinetic-energy cutoff\s*=\s*([\-\d.E+]+)\s*Ry")
+_ECUTRHO_RE = re.compile(r"charge density cutoff\s*=\s*([\-\d.E+]+)\s*Ry")
 
 
 class BaseStdoutParser(BaseOutputFileParser):
@@ -51,5 +53,13 @@ class BaseStdoutParser(BaseOutputFileParser):
         volume_matches = _VOLUME_RE.findall(content)
         if volume_matches:
             parsed_data["volume_bohr3"] = float(volume_matches[-1])
+
+        ecutwfc_match = _ECUTWFC_RE.search(content)
+        if ecutwfc_match:
+            parsed_data["ecutwfc_ry"] = float(ecutwfc_match.group(1))
+
+        ecutrho_match = _ECUTRHO_RE.search(content)
+        if ecutrho_match:
+            parsed_data["ecutrho_ry"] = float(ecutrho_match.group(1))
 
         return parsed_data

--- a/src/qe_tools/outputs/pw.py
+++ b/src/qe_tools/outputs/pw.py
@@ -50,9 +50,12 @@ class _PwParametersMapping:
     ecutwfc: Annotated[
         float,
         Spec(
-            (
-                "xml.input.basis.ecutwfc",
-                lambda ecut: ecut * CONSTANTS.hartree_to_ev,
+            Coalesce(
+                (
+                    "xml.input.basis.ecutwfc",
+                    lambda ecut: ecut * CONSTANTS.hartree_to_ev,
+                ),
+                ("stdout.ecutwfc_ry", lambda ecut: ecut * CONSTANTS.ry_to_ev),
             )
         ),
         Unit("eV"),
@@ -62,9 +65,12 @@ class _PwParametersMapping:
     ecutrho: Annotated[
         float,
         Spec(
-            (
-                "xml.input.basis.ecutrho",
-                lambda ecut: ecut * CONSTANTS.hartree_to_ev,
+            Coalesce(
+                (
+                    "xml.input.basis.ecutrho",
+                    lambda ecut: ecut * CONSTANTS.hartree_to_ev,
+                ),
+                ("stdout.ecutrho_ry", lambda ecut: ecut * CONSTANTS.ry_to_ev),
             )
         ),
         Unit("eV"),

--- a/tests/outputs/test_pw_output.py
+++ b/tests/outputs/test_pw_output.py
@@ -129,6 +129,39 @@ def test_forces_stdout_fallback_without_xml():
     assert len(pw_out.get_output("forces")) == 2
 
 
+def test_cutoffs_stdout_xml_agree():
+    """XML and stdout `ecutwfc` / `ecutrho` agree within stdout's printed precision.
+
+    QE prints both cutoffs to 4 decimal digits (`30.0000 Ry`); XML stores them in
+    Hartree. Multiplying the XML values by 2 (1 Ha = 2 Ry) puts both on the Ry scale.
+    """
+    pw_directory = Path(__file__).parent / "fixtures" / "pw" / "default_xml_220603"
+
+    pw_out = PwOutput.from_dir(pw_directory)
+    xml = pw_out.raw_outputs["xml"]["input"]["basis"]
+    stdout = pw_out.raw_outputs["stdout"]
+
+    assert 2 * xml["ecutwfc"] == pytest.approx(stdout["ecutwfc_ry"], abs=1e-4)
+    assert 2 * xml["ecutrho"] == pytest.approx(stdout["ecutrho_ry"], abs=1e-4)
+
+
+def test_cutoffs_stdout_fallback_without_xml():
+    """`PwOutput.from_files(stdout=...)` exposes the cutoffs via the stdout fallback."""
+    from qe_tools import CONSTANTS
+
+    stdout_file = (
+        Path(__file__).parent / "fixtures" / "pw" / "default_xml_220603" / "pw.out"
+    )
+
+    pw_out = PwOutput.from_files(stdout=stdout_file)
+
+    assert "xml" not in pw_out.raw_outputs
+    assert pw_out.outputs.parameters.ecutwfc == pytest.approx(30.0 * CONSTANTS.ry_to_ev)
+    assert pw_out.outputs.parameters.ecutrho == pytest.approx(
+        240.0 * CONSTANTS.ry_to_ev
+    )
+
+
 def test_k_points_stdout_xml_agree():
     """Stdout-derived k-points agree with the XML values within stdout's printed precision.
 

--- a/tests/outputs/test_pw_output/test_default_xml_211101_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_211101_.yml
@@ -101,6 +101,8 @@ base_outputs:
 raw_outputs:
   stdout:
     code_version: '7.0'
+    ecutrho_ry: 240.0
+    ecutwfc_ry: 30.0
     forces:
     - - 0.0
       - 0.0

--- a/tests/outputs/test_pw_output/test_default_xml_220603_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_220603_.yml
@@ -117,6 +117,8 @@ base_outputs:
 raw_outputs:
   stdout:
     code_version: '7.1'
+    ecutrho_ry: 240.0
+    ecutwfc_ry: 30.0
     forces:
     - - 0.0
       - 0.0

--- a/tests/outputs/test_pw_output/test_default_xml_230310_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_230310_.yml
@@ -168,6 +168,8 @@ base_outputs:
 raw_outputs:
   stdout:
     code_version: '7.2'
+    ecutrho_ry: 240.0
+    ecutwfc_ry: 30.0
     forces:
     - - 0.0
       - 0.0

--- a/tests/outputs/test_pw_output/test_default_xml_240411_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_240411_.yml
@@ -153,6 +153,8 @@ base_outputs:
 raw_outputs:
   stdout:
     code_version: 7.3.1
+    ecutrho_ry: 240.0
+    ecutwfc_ry: 30.0
     forces:
     - - 0.0
       - 0.0

--- a/tests/outputs/test_pw_output/test_default_xml_250521_.yml
+++ b/tests/outputs/test_pw_output/test_default_xml_250521_.yml
@@ -152,6 +152,8 @@ base_outputs:
 raw_outputs:
   stdout:
     code_version: '7.5'
+    ecutrho_ry: 360.0
+    ecutwfc_ry: 45.0
     forces:
     - - -0.06858972
       - 0.01765138

--- a/tests/outputs/test_pw_output/test_failed_failed_no_xml_.yml
+++ b/tests/outputs/test_pw_output/test_failed_failed_no_xml_.yml
@@ -1,7 +1,11 @@
 base_outputs:
-  parameters: {}
+  parameters:
+    ecutrho: 4898.049021108
+    ecutwfc: 612.2561276385
   volume: 65.45083006209762
 raw_outputs:
   stdout:
     code_version: '7.5'
+    ecutrho_ry: 360.0
+    ecutwfc_ry: 45.0
     volume_bohr3: 441.6841


### PR DESCRIPTION
Another parameter that we currently only parse from the XML is the energy cutoffs. This value is often used for convergence studies, where the user will likely run a calculation with different parameters in the same directory. Again, this will likely mean the XML of each calculation is no longer available.

The two regexes go on `BaseStdoutParser` rather than `PwStdoutParser` because the same lines are emitted by every plane-wave QE code (`pw.x`, `cp.x`, `neb.x` per image, ...) — placement matches `volume` and `wall_time`. Post-processing codes that lack the lines see a silent no-op miss. The two parameter Specs are wrapped in `Coalesce(xml, stdout)`, with the stdout arm applying Ry → eV via `CONSTANTS.ry_to_ev` so units match the XML-derived Hartree → eV path.